### PR TITLE
Fix for Issue 291 (Error parsing title in some feeds)

### DIFF
--- a/feedparser/feedparser.py
+++ b/feedparser/feedparser.py
@@ -552,6 +552,7 @@ class _FeedParserMixin:
         self.lang = baselang or None
         self.svgOK = 0
         self.hasTitle = 0
+        self.hasTitleBeforeImage = 0
         if baselang:
             self.feeddata['language'] = baselang.replace('_','-')
 
@@ -1108,12 +1109,14 @@ class _FeedParserMixin:
         if not self.inentry:
             context.setdefault('image', FeedParserDict())
         self.inimage = 1
+        self.hasTitleBeforeImage = self.hasTitle
         self.hasTitle = 0
         self.push('image', 0)
 
     def _end_image(self):
         self.pop('image')
         self.inimage = 0
+        self.hasTitle = self.hasTitleBeforeImage
 
     def _start_textinput(self, attrsD):
         context = self._getContext()


### PR DESCRIPTION
When there was a title tag inside an image tag in the feed before the real channel's title, feedparser did not store the title correctly.

This patch fixes this bug by remembering the status of "hasTitle" before the image tag and restoring its value after that.

Issue that is fixed by this patch: http://code.google.com/p/feedparser/issues/detail?id=291
