### PR TITLE
Add support for Podlove Simple Chapters (http://podlove.org/simple-chapters)

### DIFF
--- a/feedparser/feedparser.py
+++ b/feedparser/feedparser.py
@@ -526,7 +526,7 @@ class _FeedParserMixin:
         'http://www.w3.org/1999/xhtml':                          'xhtml',
         'http://www.w3.org/1999/xlink':                          'xlink',
         'http://www.w3.org/XML/1998/namespace':                  'xml',
-        'http://podlove.org/simple-chapters':                    'sc',
+        'http://podlove.org/simple-chapters':                    'psc',
     }
     _matchnamespaces = {}
 
@@ -568,7 +568,7 @@ class _FeedParserMixin:
         self.svgOK = 0
         self.title_depth = -1
         self.depth = 0
-        self.sc_chapters_counter = 0
+        self.psc_chapters_counter = 0
         if baselang:
             self.feeddata['language'] = baselang.replace('_','-')
 
@@ -1375,7 +1375,7 @@ class _FeedParserMixin:
         self.inentry = 1
         self.guidislink = 0
         self.title_depth = -1
-        self.sc_chapters_counter = 0
+        self.psc_chapters_counter = 0
         id = self._getAttribute(attrsD, 'rdf:about')
         if id:
             context = self._getContext()
@@ -1769,24 +1769,24 @@ class _FeedParserMixin:
             return
         context['newlocation'] = _makeSafeAbsoluteURI(self.baseuri, url.strip())
 
-    def _start_sc_chapters(self, attrsD):
+    def _start_psc_chapters(self, attrsD):
         version = self._getAttribute(attrsD, 'version')
-        if version == '1.0' and self.sc_chapters_counter == 0:
-            self.sc_chapters_counter += 1
+        if version == '1.1' and self.psc_chapters_counter == 0:
+            self.psc_chapters_counter += 1
             attrsD['chapters'] = []
-            self._getContext()['sc_chapters'] = FeedParserDict(attrsD)
+            self._getContext()['psc_chapters'] = FeedParserDict(attrsD)
             
-    def _end_sc_chapters(self):
-        version = self._getContext()['sc_chapters']['version']
-        if version == '1.0':
-            self.sc_chapters_counter += 1
+    def _end_psc_chapters(self):
+        version = self._getContext()['psc_chapters']['version']
+        if version == '1.1':
+            self.psc_chapters_counter += 1
         
-    def _start_sc_chapter(self, attrsD):
-        if self.sc_chapters_counter == 1:
+    def _start_psc_chapter(self, attrsD):
+        if self.psc_chapters_counter == 1:
             start = self._getAttribute(attrsD, 'start')
-            attrsD['start_parsed'] = _parse_sc_chapter_start(start)
+            attrsD['start_parsed'] = _parse_psc_chapter_start(start)
 
-            context = self._getContext()['sc_chapters']
+            context = self._getContext()['psc_chapters']
             context['chapters'].append(FeedParserDict(attrsD))
 
 
@@ -3147,7 +3147,7 @@ try:
 except NameError:
     pass
     
-def _parse_sc_chapter_start(start):
+def _parse_psc_chapter_start(start):
     FORMAT = r'^((\d{2}):)?(\d{2}):(\d{2})(\.(\d{3}))?$'
 
     m = re.compile(FORMAT).match(start)

--- a/feedparser/tests/illformed/namespace/atomsimplechapter.xml
+++ b/feedparser/tests/illformed/namespace/atomsimplechapter.xml
@@ -1,9 +1,8 @@
 <!--
-Description:  Simple-Chapters: only one sc:chapters element is allowed (podlove.org/simple-chapters) 
-Expect:       not bozo and len(entries[0]['sc_chapters']['chapters']) == 4 and entries[0]['sc_chapters']['version'] == '1.0'
+Description:  Simple-Chapters: only one psc:chapters element is allowed (podlove.org/simple-chapters) 
+Expect:       not bozo and len(entries[0]['psc_chapters']['chapters']) == 4 and entries[0]['psc_chapters']['version'] == '1.1'
 -->
-<feed xmlns="http://www.w3.org/2005/Atom"
- xmlns:sc="http://podlove.org/simple-chapters">
+<feed xmlns="http://www.w3.org/2005/Atom">
   <title>Podlove Podcast</title>
 
   <link href="http://podlove.org/"/>
@@ -23,17 +22,17 @@ Expect:       not bozo and len(entries[0]['sc_chapters']['chapters']) == 4 and e
      href="http://podlove.org/files/fiatlux.mp3"/>
 
     <!-- specify chapter information -->
-    <sc:chapters version="1.0">
-      <sc:chapter start="00:00:00" title="Welcome" />
-      <sc:chapter start="00:03:07.250" title="Introducing Podlove"
+    <psc:chapters version="1.1" xmlns:psc="http://podlove.org/simple-chapters">
+      <psc:chapter start="00:00:00" title="Welcome" />
+      <psc:chapter start="00:03:07.250" title="Introducing Podlove"
        href="http://podlove.org/" />
-      <sc:chapter start="08:26" title="Podlove WordPress Plugin"
+      <psc:chapter start="08:26" title="Podlove WordPress Plugin"
        href="http://podlove.org/wordpress-plugin" />
-      <sc:chapter start="12:42.345" title="Resumée" />
-    </sc:chapters>
+      <psc:chapter start="12:42.345" title="Resumée" />
+    </psc:chapters>
 
-    <sc:chapters version="2.0">
-      <sc:chapter start="00:00:00" title="Ignore me" />
-    </sc:chapters>
+    <psc:chapters version="1.1" xmlns:psc="http://podlove.org/simple-chapters">
+      <psc:chapter start="00:00:00" title="Ignore me" />
+    </psc:chapters>
   </entry>
 </feed>

--- a/feedparser/tests/wellformed/namespace/atomsimplechapter.xml
+++ b/feedparser/tests/wellformed/namespace/atomsimplechapter.xml
@@ -1,9 +1,8 @@
 <!--
 Description:  Simple-Chapters: podlove.org/simple-chapters 
-Expect:       not bozo and entries[0]['sc_chapters']['chapters'][0]['title'] == 'Welcome' and entries[0]['sc_chapters']['chapters'][1]['start_parsed'] == datetime.timedelta(0, 187, 250000)
+Expect:       not bozo and entries[0]['psc_chapters']['chapters'][0]['title'] == 'Welcome' and entries[0]['psc_chapters']['chapters'][1]['start_parsed'] == datetime.timedelta(0, 187, 250000) and entries[0]['psc_chapters']['chapters'][0]['image'] == 'testimage'
 -->
-<feed xmlns="http://www.w3.org/2005/Atom"
- xmlns:sc="http://podlove.org/simple-chapters">
+<feed xmlns="http://www.w3.org/2005/Atom">
   <title>Podlove Podcast</title>
 
   <link href="http://podlove.org/"/>
@@ -23,13 +22,13 @@ Expect:       not bozo and entries[0]['sc_chapters']['chapters'][0]['title'] == 
      href="http://podlove.org/files/fiatlux.mp3"/>
 
     <!-- specify chapter information -->
-    <sc:chapters version="1.0">
-      <sc:chapter start="00:00:00" title="Welcome" />
-      <sc:chapter start="00:03:07.250" title="Introducing Podlove"
+    <psc:chapters version="1.1" xmlns:psc="http://podlove.org/simple-chapters">
+      <psc:chapter start="00:00:00" title="Welcome" image="testimage"/>
+      <psc:chapter start="00:03:07.250" title="Introducing Podlove"
        href="http://podlove.org/" />
-      <sc:chapter start="08:26" title="Podlove WordPress Plugin"
+      <psc:chapter start="08:26" title="Podlove WordPress Plugin"
        href="http://podlove.org/wordpress-plugin" />
-      <sc:chapter start="12:42.345" title="Resumée" />
-    </sc:chapters>
+      <psc:chapter start="12:42.345" title="Resumée" />
+    </psc:chapters>
   </entry>
 </feed>

--- a/feedparser/tests/wellformed/namespace/atomsimplechapterexternal.xml
+++ b/feedparser/tests/wellformed/namespace/atomsimplechapterexternal.xml
@@ -1,0 +1,27 @@
+<!--
+Description:  Simple-Chapters: podlove.org/simple-chapters 
+Expect:       not bozo and any(link['href'] == u'http://podlove.org/examples/chapters.psc' for link in entries[0]['links']) 
+-->
+<feed xmlns:atom="http://www.w3.org/2005/Atom">
+  <title>Podlove Podcast</title>
+
+  <link href="http://podlove.org/"/>
+  <updated>2012-03-26T23:25:19Z</updated>
+  <author>
+    <name>Tim Pritlove</name>
+  </author>
+  <id>urn:uuid:8d5261ba-bf62-ac81-946c-9276ea617917c</id>
+
+  <entry>
+    <title>Fiat Lux</title>
+    <link href="http://podlove.org/podcast/1"/>
+    <id>urn:uuid:3241ace2-ca21-dd12-2341-1412ce31fad2</id>
+    <updated>2012-03-26T23:25:19Z</updated>
+    <summary>First episode</summary>
+    <link rel="enclosure" type="audio/mpeg" length="12345"
+     href="http://podlove.org/files/fiatlux.mp3"/>
+
+    <!-- specify chapter information -->
+    <atom:link rel="http://podlove.org/simple-chapters" href="http://podlove.org/examples/chapters.psc" />
+  </entry>
+</feed>

--- a/feedparser/tests/wellformed/namespace/rss2.0simplechapter.xml
+++ b/feedparser/tests/wellformed/namespace/rss2.0simplechapter.xml
@@ -1,8 +1,8 @@
 <!--
 Description:  Simple-Chapters: podlove.org/simple-chapters 
-Expect:       not bozo and entries[0]['sc_chapters']['chapters'][0]['title'] == 'Welcome' and entries[0]['sc_chapters']['chapters'][1]['start_parsed'] == datetime.timedelta(0, 187, 250000)
+Expect:       not bozo and entries[0]['psc_chapters']['chapters'][0]['title'] == 'Welcome' and entries[0]['psc_chapters']['chapters'][1]['start_parsed'] == datetime.timedelta(0, 187, 250000)
 -->
-<rss version = "2.0" xmlns:sc="http://podlove.org/simple-chapters">
+<rss version = "2.0">
 <channel>
   <title>Podlove Podcast</title>
 
@@ -23,14 +23,14 @@ Expect:       not bozo and entries[0]['sc_chapters']['chapters'][0]['title'] == 
      href="http://podlove.org/files/fiatlux.mp3"/>
 
     <!-- specify chapter information -->
-    <sc:chapters version="1.0">
-      <sc:chapter start="00:00:00" title="Welcome" />
-      <sc:chapter start="00:03:07.250" title="Introducing Podlove"
+    <psc:chapters version="1.1" xmlns:psc="http://podlove.org/simple-chapters">
+      <psc:chapter start="00:00:00" title="Welcome" />
+      <psc:chapter start="00:03:07.250" title="Introducing Podlove"
        href="http://podlove.org/" />
-      <sc:chapter start="08:26" title="Podlove WordPress Plugin"
+      <psc:chapter start="08:26" title="Podlove WordPress Plugin"
        href="http://podlove.org/wordpress-plugin" />
-      <sc:chapter start="12:42.345" title="Resumée" />
-    </sc:chapters>
+      <psc:chapter start="12:42.345" title="Resumée" />
+    </psc:chapters>
   </item>
 </channel>
 </rss>

--- a/feedparser/tests/wellformed/namespace/rss2.0simplechapter2items.xml
+++ b/feedparser/tests/wellformed/namespace/rss2.0simplechapter2items.xml
@@ -1,22 +1,22 @@
 <!--
 Description:  Simple-Chapters: podlove.org/simple-chapters with two items
-Expect:       not bozo and entries[0]['sc_chapters']['chapters'][0]['title'] == u'Livekalender' and entries[0]['sc_chapters']['chapters'][0]['start_parsed'] == datetime.timedelta(0, 12)
+Expect:       not bozo and entries[0]['psc_chapters']['chapters'][0]['title'] == u'Livekalender' and entries[0]['psc_chapters']['chapters'][0]['start_parsed'] == datetime.timedelta(0, 12)
 -->
-<rss version="2.0" xmlns:sc="http://podlove.org/simple-chapters">
-<channel>
-	<item>
-		<title>Vorhersage Donnerstag, 06.09.2012</title>
-		<sc:chapters version="1.0">
-			<sc:chapter start="00:00:12.000" title="Livekalender" />
-			<sc:chapter start="00:02:24.000" title="Podcatcher" />
-		</sc:chapters>
-	</item>
-	<item>
-		<title>Vorhersage Donnerstag, 05.09.2012</title>
-		<sc:chapters version="1.0">
-			<sc:chapter start="00:00:12.000" title="Livekalender" />
-			<sc:chapter start="00:00:46.000" title="Podcatcher" />
-		</sc:chapters>
-	</item>
-</channel>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title>Vorhersage Donnerstag, 06.09.2012</title>
+      <psc:chapters version="1.1" xmlns:psc="http://podlove.org/simple-chapters">
+        <psc:chapter start="00:00:12.000" title="Livekalender" />
+        <psc:chapter start="00:02:24.000" title="Podcatcher" />
+      </psc:chapters>
+    </item>
+    <item>
+      <title>Vorhersage Donnerstag, 05.09.2012</title>
+      <psc:chapters version="1.1" xmlns:psc="http://podlove.org/simple-chapters">
+        <psc:chapter start="00:00:12.000" title="Livekalender" />
+        <psc:chapter start="00:00:46.000" title="Podcatcher" />
+      </psc:chapters>
+    </item>
+  </channel>
 </rss>


### PR DESCRIPTION
Implemented support for the extension of the Atom Syndication and RSS 2.0 file format with simple chapter information described in this specification:
http://podlove.org/simple-chapters/

Example:
    In [1]: import feedparser

```
In [2]: feed = feedparser.parse('http://hoersuppe.de/vorcast/')

In [3]: feed['entries'][0]['sc_chapters']
Out[3]: 
{'chapters': [{'start': u'00:00:12.000',
   'start_parsed': datetime.timedelta(0, 12),
   'title': u'Livekalender'},
  {'start': u'00:02:24.000',
   'start_parsed': datetime.timedelta(0, 144),
   'title': u'Podcatcher'}],
 'version': u'1.0'}
```
