### PR TITLE
Add parsing of RFC822 date with extra whitespace (issue 366)

### DIFF
--- a/feedparser/feedparser.py
+++ b/feedparser/feedparser.py
@@ -3464,7 +3464,7 @@ _rfc822_tznames = {
     'm': -12, 'y': 12,
  }
 # The timezone may be prefixed by 'Etc/'
-_rfc822_time = "%s (?:etc/)?%s" % (_rfc822_hour, _rfc822_tz)
+_rfc822_time = "%s[ ]{1,2}(?:etc/)?%s" % (_rfc822_hour, _rfc822_tz)
 
 _rfc822_dayname = "(?P<dayname>%s)" % ('|'.join(_rfc822_daynames))
 _rfc822_match = re.compile(

--- a/feedparser/feedparsertest.py
+++ b/feedparser/feedparsertest.py
@@ -587,6 +587,7 @@ date_tests = {
         (u'Wed, 19 Aug 2009 18:28:00 Etc/GMT', (2009, 8, 19, 18, 28, 0, 2, 231, 0)), # etc/gmt timezone
         (u'Wed, 19 Feb 2012 22:40:00 GMT-01:01', (2012, 2, 19, 23, 41, 0, 6, 50, 0)), # gmt+hh:mm timezone
         (u'Mon, 13 Feb, 2012 06:28:00 UTC', (2012, 2, 13, 6, 28, 0, 0, 44, 0)), # extraneous comma
+        (u'Wed, 04 Jul 2012 16:01:30  +0200', (2012, 7, 4, 14, 1, 30, 2, 186, 0)), # extra space
         (u'Thu, 01 Jan 2004 00:00 GMT', (2004, 1, 1, 0, 0, 0, 3, 1, 0)), # no seconds
         (u'Thu, 01 Jan 2004', (2004, 1, 1, 0, 0, 0, 3, 1, 0)), # no time
         # Additional tests to handle Disney's long month names and invalid timezones


### PR DESCRIPTION
This is the patch for the issue 366 on google-code:
http://code.google.com/p/feedparser/issues/detail?id=366
