### PR TITLE
Handle attributes containing urls with character references.

### DIFF
--- a/feedparser/tests/wellformed/rss/item_description_escaped_attribute.xml
+++ b/feedparser/tests/wellformed/rss/item_description_escaped_attribute.xml
@@ -1,0 +1,11 @@
+<!--
+Description: escaped markup in item description
+Expect:      not bozo and entries[0]['description'] == u'<a href="https://example.iana.org/file?id=1">Link</a>'
+-->
+<rss version="2.0">
+<channel>
+<item>
+<description><![CDATA[<a href="https:&#x2F;&#x2F;example.iana.org&#x2F;file?id=1">Link</a>]]></description>
+</item>
+</channel>
+</rss>


### PR DESCRIPTION
Currently hrefs in the description are mangled if their scheme contains character references.  These changes improve their handling.

Motivated by: https://github.com/HackerNews/HN/issues/2