### PR TITLE
Added support for multiple dc:creator elements

### DIFF
--- a/feedparser/feedparser.py
+++ b/feedparser/feedparser.py
@@ -1286,7 +1286,8 @@ class _FeedParserMixin:
     def _push_detail_to_authors(self, prefix='author'):
         context = self._getContext()
         context.setdefault('authors', [FeedParserDict()])
-        context['authors'][-1] = FeedParserDict(context[prefix + '_detail'])
+        if prefix + '_detail' in context:
+            context['authors'][-1] = FeedParserDict(context[prefix + '_detail'])
 
     def _save_contributor(self, key, value):
         context = self._getContext()

--- a/feedparser/feedparser.py
+++ b/feedparser/feedparser.py
@@ -1144,6 +1144,9 @@ class _FeedParserMixin:
         context = self._getContext()
         context.setdefault('authors', [])
         context['authors'].append(FeedParserDict())
+        # Reset the author and author_detail keys in the context in the case this is the second author encountered
+        context.pop('author',None)
+        context.pop('author_detail',None)
     _start_managingeditor = _start_author
     _start_dc_author = _start_author
     _start_dc_creator = _start_author
@@ -1153,6 +1156,7 @@ class _FeedParserMixin:
         self.pop('author')
         self.inauthor = 0
         self._sync_author_detail()
+        self._push_detail_to_authors()
     _end_managingeditor = _end_author
     _end_dc_author = _end_author
     _end_dc_creator = _end_author
@@ -1278,8 +1282,11 @@ class _FeedParserMixin:
         context.setdefault(prefix + '_detail', FeedParserDict())
         context[prefix + '_detail'][key] = value
         self._sync_author_detail()
+
+    def _push_detail_to_authors(self, prefix='author'):
+        context = self._getContext()
         context.setdefault('authors', [FeedParserDict()])
-        context['authors'][-1][key] = value
+        context['authors'][-1] = FeedParserDict(context[prefix + '_detail'])
 
     def _save_contributor(self, key, value):
         context = self._getContext()

--- a/feedparser/tests/wellformed/rss/item_multiple_dc_creator.xml
+++ b/feedparser/tests/wellformed/rss/item_multiple_dc_creator.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Description: item contains multiple dc:creator
+Expect:      not bozo and (entries[0]['authors'][0]['name'] == u'First Author') and (entries[0]['authors'][1]['name'] == u'Second Author')
+-->
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<channel>
+<item>
+<dc:creator>First Author</dc:creator>
+<dc:creator>Second Author</dc:creator>
+</item>
+</channel>
+</rss>


### PR DESCRIPTION
Added support for multiple dc:creator elements in an item.

Fixes [Issue 342](https://code.google.com/p/feedparser/issues/detail?id=342)