### PR TITLE
Store isPermaLink attribute as guidispermalink

### DIFF
--- a/feedparser/feedparser.py
+++ b/feedparser/feedparser.py
@@ -1650,6 +1650,7 @@ class _FeedParserMixin:
     def _end_guid(self):
         value = self.pop('id')
         self._save('guidislink', self.guidislink and 'link' not in self._getContext())
+        self._save('guidispermalink', self.guidislink)
         if self.guidislink:
             # guid acts as link, but only if 'ispermalink' is not present or is 'true',
             # and only if the item doesn't already have a link element

--- a/feedparser/tests/wellformed/rss/item_guid_guidispermalink.xml
+++ b/feedparser/tests/wellformed/rss/item_guid_guidispermalink.xml
@@ -1,0 +1,14 @@
+<!--
+Description: guidispermalink is True if isPermaLink is set to "true" or not specified
+Expect:      not bozo and entries[0]['guidispermalink'] and entries[1]['guidispermalink']
+-->
+<rss version="2.0">
+<channel>
+<item>
+<guid>http://guid.example.com/</guid>
+</item>
+<item>
+<guid isPermaLink="true">http://guid.example.com/</guid>
+</item>
+</channel>
+</rss>

--- a/feedparser/tests/wellformed/rss/item_guid_guidispermalink_false.xml
+++ b/feedparser/tests/wellformed/rss/item_guid_guidispermalink_false.xml
@@ -1,0 +1,11 @@
+<!--
+Description: guidispermalink is False if isPermaLink is set to "false"
+Expect:      not bozo and not entries[0]['guidispermalink']
+-->
+<rss version="2.0">
+<channel>
+<item>
+<guid isPermaLink="false">not a permalink</guid>
+</item>
+</channel>
+</rss>


### PR DESCRIPTION
Hi Kurt,

Currently, there's no way to know the value of the `isPermaLink` attribute on a RSS `<guid>` element once the feed has been parsed.

With this commit, store the value as `entries[i].guidispermalink`. Tests are also included.