### PR TITLE
Add test case to emphasize an issue with encoding detection

### DIFF
--- a/feedparser/tests/encoding/bozo_http_text_xml_charset.xml
+++ b/feedparser/tests/encoding/bozo_http_text_xml_charset.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!--
+Header:      Content-type: text/xml; charset=utf-8
+Description: text/xml + charset
+Expect:      bozo and encoding == 'utf-8'
+-->
+<rss version="2.0">
+</rss>


### PR DESCRIPTION
When HTTP Content-Type is `text/xml` with an explicit charset (e.g.,
`UTF-8`) detected encoding must be whatever is specified as charset.
