### PR TITLE
Support for network request timeout

### DIFF
--- a/feedparser/exceptions.py
+++ b/feedparser/exceptions.py
@@ -50,3 +50,8 @@ class NonXMLContentType(ThingsNobodyCaresAboutButMe):
 
 class UndeclaredNamespace(Exception):
     pass
+
+
+class ReadTimeoutError(RuntimeError):
+    def __init__(self, url, timeout):
+        super(ReadTimeoutError, self).__init__(url, timeout)

--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -138,7 +138,9 @@ def _build_urllib2_request(url, agent, accept_header, etag, modified, referrer, 
     request.add_header('A-IM', 'feed') # RFC 3229 support
     return request
 
-def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, result=None):
+
+def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None,
+        result=None, timeout=None):
     if handlers is None:
         handlers = []
     elif not isinstance(handlers, list):
@@ -172,7 +174,9 @@ def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None,
     request = _build_urllib2_request(url, agent, ACCEPT_HEADER, etag, modified, referrer, auth, request_headers)
     opener = urllib.request.build_opener(*tuple(handlers + [_FeedURLHandler()]))
     opener.addheaders = [] # RMK - must clear so we only send our custom User-Agent
-    f = opener.open(request)
+
+    mb_timeout = {'timeout': timeout} if timeout is not None else {}
+    f = opener.open(request, **mb_timeout)
     data = f.read()
     f.close()
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if sys.version_info >= (3, ):
 
 setup(
     name = 'feedparser',
-    version = '5.2.1',
+    version = '5.3.1',
     description = 'Universal feed parser, handles RSS 0.9x, RSS 1.0, '
                   'RSS 2.0, CDF, Atom 0.3, and Atom 1.0 feeds',
     author = 'Kurt McKee',


### PR DESCRIPTION
Default HTTP timeout is infinite. So feed can block request forever.
Specifying timeout allows to control execution flow.