### PR TITLE
add new parameter "forced_encode" to specify the encode of url by force.

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -69,6 +69,14 @@ Parsing a feed from a string
     >>> d['feed']['title']
     u'Sample Feed'
 
+Specify the encoding of URL
+---------------------------
+::
+
+    >>> d = feedparser.parse('https://bbs.ustc.edu.cn/cgi/bbsrss?board=Intern', forced_encode='gb2312')
+    >>> print d.entries[2].title
+    达能亚太（上海）
+
 
 Values are returned as :program:`Python` Unicode strings (except when they're
 not -- see :ref:`advanced.encoding` for all the gory details).

--- a/feedparser/api.py
+++ b/feedparser/api.py
@@ -175,7 +175,7 @@ StrictFeedParser = type(str('StrictFeedParser'), (
     _StrictFeedParser, _FeedParserMixin, xml.sax.handler.ContentHandler, object
 ), {})
 
-def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, response_headers=None):
+def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, response_headers=None, forced_encode=None):
     '''Parse a feed from a URL, file, stream, or string.
 
     request_headers, if given, is a dict from http header name to value to add
@@ -200,8 +200,10 @@ def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, refer
 
     # overwrite existing headers using response_headers
     result['headers'].update(response_headers or {})
-
-    data = convert_to_utf8(result['headers'], data, result)
+    try:
+        data = convert_to_utf8(result['headers'], data, result, forced_encode)
+    except (UnicodeDecodeError, LookupError):
+        raise
     use_strict_parser = result['encoding'] and True or False
 
     result['version'], data, entities = replace_doctype(data)

--- a/feedparser/encodings.py
+++ b/feedparser/encodings.py
@@ -39,7 +39,7 @@ except ImportError:
     chardet = None
     lazy_chardet_encoding = None
 else:
-    def lazy_chardet_encoding():
+    def lazy_chardet_encoding(data):
         chardet_encoding = chardet.detect(data)['encoding']
         if not chardet_encoding:
             chardet_encoding = ''
@@ -257,7 +257,7 @@ def convert_to_utf8(http_headers, data, result, forced_encode):
     for proposed_encoding in (rfc3023_encoding, xml_encoding, bom_encoding,
                               lazy_chardet_encoding, 'utf-8', 'windows-1252', 'iso-8859-2'):
         if isinstance(proposed_encoding, collections.Callable):
-            proposed_encoding = proposed_encoding()
+            proposed_encoding = proposed_encoding(data)
         if not proposed_encoding:
             continue
         if proposed_encoding in tried_encodings:


### PR DESCRIPTION
It is happen that when I wanna to parse a rss(https://bbs.ustc.edu.cn/cgi/bbsrss?board=Intern), the rss xml has a out-bound boze.
So, it cause the encoding-detection error.

`>>>feedparser.parse("https://bbs.ustc.edu.cn/cgi/bbsrss?board=Intern")`
`document declared as gb18030, but parsed as ISO-8859-2`

as the above code shows, the actual encode is gb2312/gb18030, but because of a bozo in xml, it cause the detection error.
