### PR TITLE
Initialize result dict before use

### DIFF
--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -145,6 +145,8 @@ def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None,
         handlers = [handlers]
     if request_headers is None:
         request_headers = {}
+    if request is None:
+        request = {}
 
     # Deal with the feed URI scheme
     if url.startswith('feed:http'):


### PR DESCRIPTION
`http.get` sets the kwarg `result` default to `None` then tries to use the dict. This throws a `TypeError` when trying to assign an item to `None`.

As of now, the only use of `http.get` is in [`api.py`](https://github.com/kurtmckee/feedparser/blob/develop/feedparser/api.py#L148), where a `result` dict is passed in. However, just as [`request_headers`](https://github.com/kurtmckee/feedparser/blob/develop/feedparser/http.py#L146) and other fields are initialized, it's a good idea to initialize `result` as well.