### PR TITLE
Change to use cchardet prior to chardet when the package installed

### DIFF
--- a/feedparser/encodings.py
+++ b/feedparser/encodings.py
@@ -34,7 +34,10 @@ import collections
 import re
 
 try:
-    import chardet
+    try:
+        import cchardet as chardet
+    except ImportError:
+        import chardet
 except ImportError:
     chardet = None
     lazy_chardet_encoding = None


### PR DESCRIPTION
I think that it is good to use cchardet. For instance, [aiohttp](http://aiohttp.readthedocs.io/en/stable/) are doing in the same way.
