### PR TITLE
Add option feedparser.parse(no_gzip=False) - close #73

### DIFF
--- a/feedparser/api.py
+++ b/feedparser/api.py
@@ -106,7 +106,7 @@ SUPPORTED_VERSIONS = {
     'cdf': 'CDF',
 }
 
-def _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result):
+def _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, no_gzip, result):
     """URL, filename, or string --> stream
 
     This function lets you define parsers that take any input source
@@ -145,7 +145,7 @@ def _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, h
 
     if isinstance(url_file_stream_or_string, basestring) \
        and urllib.parse.urlparse(url_file_stream_or_string)[0] in ('http', 'https', 'ftp', 'file', 'feed'):
-        return http.get(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result)
+        return http.get(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, no_gzip, result)
 
     # try to open with native open function (if url_file_stream_or_string is a filename)
     try:
@@ -175,7 +175,7 @@ StrictFeedParser = type(str('StrictFeedParser'), (
     _StrictFeedParser, _FeedParserMixin, xml.sax.handler.ContentHandler, object
 ), {})
 
-def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, response_headers=None):
+def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, response_headers=None, no_gzip=False):
     '''Parse a feed from a URL, file, stream, or string.
 
     request_headers, if given, is a dict from http header name to value to add
@@ -193,7 +193,7 @@ def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, refer
         headers = {},
     )
 
-    data = _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result)
+    data = _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, no_gzip, result)
 
     if not data:
         return result

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -353,7 +353,7 @@ class TestOpenResource(unittest.TestCase):
     "Ensure that `_open_resource()` interprets its arguments as URIs, " \
     "file-like objects, or in-memory feeds as expected"
     def test_fileobj(self):
-        r = feedparser.api._open_resource(feedparser.api._StringIO(b''), '', '', '', '', [], {}, {})
+        r = feedparser.api._open_resource(feedparser.api._StringIO(b''), '', '', '', '', [], {}, False, {})
         self.assertEqual(r, b'')
     def test_feed(self):
         f = feedparser.parse('feed://localhost:8097/tests/http/target.xml')
@@ -363,19 +363,19 @@ class TestOpenResource(unittest.TestCase):
         self.assertEqual(f.href, 'http://localhost:8097/tests/http/target.xml')
     def test_bytes(self):
         s = b'<feed><item><title>text</title></item></feed>'
-        r = feedparser.api._open_resource(s, '', '', '', '', [], {}, {})
+        r = feedparser.api._open_resource(s, '', '', '', '', [], {}, False, {})
         self.assertEqual(s, r)
     def test_string(self):
         s = b'<feed><item><title>text</title></item></feed>'
-        r = feedparser.api._open_resource(s, '', '', '', '', [], {}, {})
+        r = feedparser.api._open_resource(s, '', '', '', '', [], {}, False, {})
         self.assertEqual(s, r)
     def test_unicode_1(self):
         s = b'<feed><item><title>text</title></item></feed>'
-        r = feedparser.api._open_resource(s, '', '', '', '', [], {}, {})
+        r = feedparser.api._open_resource(s, '', '', '', '', [], {}, False, {})
         self.assertEqual(s, r)
     def test_unicode_2(self):
         s = b'<feed><item><title>t\u00e9xt</title></item></feed>'
-        r = feedparser.api._open_resource(s, '', '', '', '', [], {}, {})
+        r = feedparser.api._open_resource(s, '', '', '', '', [], {}, False, {})
         self.assertEqual(s, r)
 
 class TestMakeSafeAbsoluteURI(unittest.TestCase):
@@ -439,6 +439,9 @@ class TestCompression(unittest.TestCase):
         self.assertEqual(f.bozo, 1)
         # Python 3.4 throws an EOFError that gets overwritten as xml.sax.SAXException later.
         self.assertTrue(isinstance(f.bozo_exception, (xml.sax.SAXException, struct.error)))
+    def test_gzip_has_no_etag(self):
+        f = feedparser.parse('http://localhost:8097/tests/compression/gzip.gz')
+        self.assertTrue('etag' not in f)
     def test_zlib_good(self):
         f = feedparser.parse('http://localhost:8097/tests/compression/deflate.z')
         self.assertEqual(f.version, 'atom10')
@@ -761,7 +764,7 @@ def runtests():
     # there are several compression test cases that must be accounted for
     # as well as a number of http status tests that redirect to a target
     # and a few `_open_resource`-related tests
-    httpcount = 6 + 16 + 2
+    httpcount = 7 + 16 + 2
     httpcount += len([f for f in allfiles if 'http' in f])
     httpcount += len([f for f in wellformedfiles if 'http' in f])
     httpcount += len([f for f in illformedfiles if 'http' in f])


### PR DESCRIPTION
I'm building a thing with feedparser and I'd like to rely on ETags as much as possible. A bunch of webserver versions don't provide ETags with gzipped content.

Currently the way feedparser decides whether to ask for gzip or not is by checking whether python supports gzip:

``` python
try:
    import gzip
except ImportError:
    gzip = None
```

…

``` python
    if gzip and zlib:
        request.add_header('Accept-encoding', 'gzip, deflate')
    elif gzip:
        request.add_header('Accept-encoding', 'gzip')
```

This PR adds an optional `no_gzip` flag to `feedparser.parse()`
