### PR TITLE
Added a timeout parameter to the parse function

### DIFF
--- a/feedparser/api.py
+++ b/feedparser/api.py
@@ -106,7 +106,7 @@ SUPPORTED_VERSIONS = {
     'cdf': 'CDF',
 }
 
-def _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result):
+def _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result, timeout):
     """URL, filename, or string --> stream
 
     This function lets you define parsers that take any input source
@@ -145,7 +145,7 @@ def _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, h
 
     if isinstance(url_file_stream_or_string, basestring) \
        and urllib.parse.urlparse(url_file_stream_or_string)[0] in ('http', 'https', 'ftp', 'file', 'feed'):
-        return http.get(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result)
+        return http.get(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result, timeout)
 
     # try to open with native open function (if url_file_stream_or_string is a filename)
     try:
@@ -175,7 +175,7 @@ StrictFeedParser = type(str('StrictFeedParser'), (
     _StrictFeedParser, _FeedParserMixin, xml.sax.handler.ContentHandler, object
 ), {})
 
-def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, response_headers=None):
+def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, response_headers=None, timeout=30):
     '''Parse a feed from a URL, file, stream, or string.
 
     request_headers, if given, is a dict from http header name to value to add
@@ -193,7 +193,7 @@ def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, refer
         headers = {},
     )
 
-    data = _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result)
+    data = _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result, timeout)
 
     if not data:
         return result

--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -138,7 +138,7 @@ def _build_urllib2_request(url, agent, accept_header, etag, modified, referrer, 
     request.add_header('A-IM', 'feed') # RFC 3229 support
     return request
 
-def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, result=None):
+def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, result=None, timeout=30):
     if handlers is None:
         handlers = []
     elif not isinstance(handlers, list):
@@ -172,7 +172,7 @@ def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None,
     request = _build_urllib2_request(url, agent, ACCEPT_HEADER, etag, modified, referrer, auth, request_headers)
     opener = urllib.request.build_opener(*tuple(handlers + [_FeedURLHandler()]))
     opener.addheaders = [] # RMK - must clear so we only send our custom User-Agent
-    f = opener.open(request)
+    f = opener.open(request, timeout=timeout)
     data = f.read()
     f.close()
 


### PR DESCRIPTION
The default is set to 30 seconds.

I only saw https://github.com/kurtmckee/feedparser/pull/77 after I made my corrections. However PR 77 introduces a hardcoded parameter, and does not respect the API of feedparser.

I recommend using this PR instead of 77.

Usage:

``` python
    feed = feedparser.parse("http://feeds.rsc.org/rss/cc", timeout=1)
```

But old syntax will still work, of course:

``` python
    feed = feedparser.parse("http://feeds.rsc.org/rss/cc")
```
