### PR TITLE
Simple feed streaming

### DIFF
--- a/feedparser/__init__.py
+++ b/feedparser/__init__.py
@@ -37,7 +37,7 @@ __version__ = '5.2.1'
 USER_AGENT = "feedparser/%s +https://github.com/kurtmckee/feedparser/" % __version__
 
 from . import api
-from .api import parse
+from .api import parse, stream
 from .datetimes import registerDateHandler
 from .exceptions import *
 

--- a/feedparser/__init__.py
+++ b/feedparser/__init__.py
@@ -37,7 +37,7 @@ __version__ = '5.2.1'
 USER_AGENT = "feedparser/%s +https://github.com/kurtmckee/feedparser/" % __version__
 
 from . import api
-from .api import parse, stream
+from .api import parse, stream_entries
 from .datetimes import registerDateHandler
 from .exceptions import *
 

--- a/feedparser/api.py
+++ b/feedparser/api.py
@@ -247,10 +247,10 @@ def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, refer
     result['namespaces'] = feedparser.namespacesInUse
     return result
 
-def stream(url, id_tag='id', snooze_time=30, **kwargs):
+def stream_entries(url_file_stream_or_string, id_tag='id', snooze_time=30, **kwargs):
     seen_ids = set()
     while True:
-        feed_data = parse(url, **kwargs)
+        feed_data = parse(url_file_stream_or_string, **kwargs)
         for entry in reversed(feed_data['entries']):
             try:
                 entry_id = entry[id_tag]

--- a/feedparser/api.py
+++ b/feedparser/api.py
@@ -247,7 +247,7 @@ def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, refer
     result['namespaces'] = feedparser.namespacesInUse
     return result
 
-def stream(url, id_tag='id', snooze_time=5, **kwargs):
+def stream(url, id_tag='id', snooze_time=30, **kwargs):
     seen_ids = set()
     while True:
         feed_data = parse(url, **kwargs)

--- a/feedparser/exceptions.py
+++ b/feedparser/exceptions.py
@@ -34,6 +34,7 @@ __all__ = [
     'CharacterEncodingUnknown',
     'NonXMLContentType',
     'UndeclaredNamespace',
+    'IdTagNotFound',
 ]
 
 class ThingsNobodyCaresAboutButMe(Exception):
@@ -49,4 +50,7 @@ class NonXMLContentType(ThingsNobodyCaresAboutButMe):
     pass
 
 class UndeclaredNamespace(Exception):
+    pass
+
+class IdTagNotFound(Exception):
     pass


### PR DESCRIPTION
This PR provides a simple API to continuously stream newly added entries from the given feed. Inspired by [tweepy](https://github.com/tweepy/tweepy/blob/master/tweepy/streaming.py#L190) and [praw](https://github.com/praw-dev/praw/blob/master/praw/models/util.py#L80) which both support similar functionality.

It's still fairly rough, and extremely simple, but I think with a little polish it can provide a nice addition to functionality with very little upkeep cost. The functionality is very simple:

1. Call feedparser.parse on input
2. yield each entry not already seen, and add to seen
    - a tag with unique data for each entry can be specified (default is 'id')
3. sleep for a specified amount of time (default is 30 seconds)
    - adding threading may boost performance because sleep is blocking

This repeats until the user breaks the loop. Called like this:

```
import feedparser

for entry in feedparser.stream_entries('https://www.reddit.com/r/programming/new.rss'):
    print(entry)
```