### PR TITLE
Added timeout argument

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -14,6 +14,7 @@ bug report!
 * `John Beimler <http://john.beimler.org/>`_
 * `François Boulogne <http://www.sciunto.org/>`_
 * `Jason Diamond <http://injektilo.org/>`_
+* `Andrea Esuli <http://www.esuli.it/>`_
 * `Fazal Majid <https://majid.info/blog/>`_
 * `Kevin Marks <http://epeus.blogspot.com/>`_
 * `Nik Nyby <http://nikolas.us.to/>`_

--- a/docs/http-timeout.rst
+++ b/docs/http-timeout.rst
@@ -1,0 +1,18 @@
+Password-Protected Feeds
+========================
+
+:program:`Universal Feed Parser` by default has no timeout on the http requests it makes.
+A timeout argument can be added to the parse function to return from the request after the specified amount on time, in seconds, has passed.
+
+::
+
+    >>> import feedparser
+    >>> timeout = 30
+    >>> d = feedparser.parse('http://feedparser.org/docs/examples/atom10.xml', timeout=timeout)
+    >>> d.feed.title
+    u'Sample Feed'
+
+
+.. note::
+
+    By default there is no timeout. This is to preserve the original behaviour and backward compatibility with code developed on older versions of the library.

--- a/feedparser/api.py
+++ b/feedparser/api.py
@@ -106,7 +106,7 @@ SUPPORTED_VERSIONS = {
     'cdf': 'CDF',
 }
 
-def _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result):
+def _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result, timeout=None):
     """URL, filename, or string --> stream
 
     This function lets you define parsers that take any input source
@@ -145,7 +145,7 @@ def _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, h
 
     if isinstance(url_file_stream_or_string, basestring) \
        and urllib.parse.urlparse(url_file_stream_or_string)[0] in ('http', 'https', 'ftp', 'file', 'feed'):
-        return http.get(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result)
+        return http.get(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result, timeout)
 
     # try to open with native open function (if url_file_stream_or_string is a filename)
     try:
@@ -175,7 +175,7 @@ StrictFeedParser = type(str('StrictFeedParser'), (
     _StrictFeedParser, _FeedParserMixin, xml.sax.handler.ContentHandler, object
 ), {})
 
-def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, response_headers=None):
+def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, response_headers=None, timeout=None):
     '''Parse a feed from a URL, file, stream, or string.
 
     request_headers, if given, is a dict from http header name to value to add
@@ -193,7 +193,7 @@ def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, refer
         headers = {},
     )
 
-    data = _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result)
+    data = _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result, timeout)
 
     if not data:
         return result

--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -138,7 +138,7 @@ def _build_urllib2_request(url, agent, accept_header, etag, modified, referrer, 
     request.add_header('A-IM', 'feed') # RFC 3229 support
     return request
 
-def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, result=None):
+def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, result=None, timeout=None):
     if handlers is None:
         handlers = []
     elif not isinstance(handlers, list):
@@ -172,7 +172,11 @@ def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None,
     request = _build_urllib2_request(url, agent, ACCEPT_HEADER, etag, modified, referrer, auth, request_headers)
     opener = urllib.request.build_opener(*tuple(handlers + [_FeedURLHandler()]))
     opener.addheaders = [] # RMK - must clear so we only send our custom User-Agent
-    f = opener.open(request)
+    if not timeout:
+        # preserve old behavior, no timeout
+        f = opener.open(request)
+    else:
+        f = opener.open(request, timeout=timeout)
     data = f.read()
     f.close()
 


### PR DESCRIPTION
I have added a timeout argument to the parse function.
It's implemented so that the default behavior is the original one, no timeout.
Old code using feedparser won't break and won't notice the difference.