### PR TITLE
Fix Python 3 conditional dependency specification

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -16,6 +16,7 @@ bug report!
 * `Jason Diamond <http://injektilo.org/>`_
 * `Fazal Majid <https://majid.info/blog/>`_
 * `Kevin Marks <http://epeus.blogspot.com/>`_
+* `Tom Most <https://github.com/twm/>`_
 * `Nik Nyby <http://nikolas.us.to/>`_
 * `Ade Oshineye <http://blog.oshineye.com/>`_
 * `Martin Pool <http://sourcefrog.net/>`_

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,4 @@
 from setuptools import setup
-import sys
-
-extra = {}
-if sys.version_info >= (3, ):
-    extra['install_requires'] = ['sgmllib3k']
 
 setup(
     name = 'feedparser',
@@ -16,6 +11,9 @@ setup(
     download_url = 'https://pypi.python.org/pypi/feedparser',
     platforms = ['POSIX', 'Windows'],
     packages = ['feedparser', 'feedparser.datetimes', 'feedparser.namespaces', 'feedparser.parsers'],
+    install_requires = [
+        'sgmllib3k;python_version>="3.0"',
+    ],
     keywords = ['atom', 'cdf', 'feed', 'parser', 'rdf', 'rss'],
     classifiers = [
         'Development Status :: 5 - Production/Stable',
@@ -33,5 +31,4 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Text Processing :: Markup :: XML',
     ],
-    **extra
 )


### PR DESCRIPTION
Use a [platform specific dependency](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies) to pull in libsgml3k on Python 3 in a way that will generate proper wheel metadata. With these changes a universal wheel is built that depends on sgmllib3k only on Python 3:

```
$ python setup.py bdist_wheel
running bdist_wheel
[...]
creating build/bdist.linux-x86_64/wheel/feedparser-5.2.1.dist-info/WHEEL

$ ls dist/
feedparser-5.2.1-py2.py3-none-any.whl

$ cd dist/

$ virtualenv --python=python2.7 env2
Already using interpreter /usr/bin/python2.7
New python executable in /home/twm/feedparser/dist/env2/bin/python2.7
Also creating executable in /home/twm/feedparser/dist/env2/bin/python
Installing setuptools, pip, wheel...done.

$ env2/bin/pip install --no-cache feedparser-5.2.1-py2.py3-none-any.whl 
Processing ./feedparser-5.2.1-py2.py3-none-any.whl
Installing collected packages: feedparser
Successfully installed feedparser-5.2.1

$ virtualenv --python=python3.5 env3
Running virtualenv with interpreter /usr/bin/python3.5
Using base prefix '/usr'
New python executable in /home/twm/feedparser/dist/env3/bin/python3.5
Also creating executable in /home/twm/feedparser/dist/env3/bin/python
Installing setuptools, pip, wheel...done.

$ env3/bin/pip install --no-cache feedparser-5.2.1-py2.py3-none-any.whl 
Processing ./feedparser-5.2.1-py2.py3-none-any.whl
Collecting sgmllib3k; python_version >= "3.0" (from feedparser==5.2.1)
  Downloading sgmllib3k-1.0.0.tar.gz
Installing collected packages: sgmllib3k, feedparser
  Running setup.py install for sgmllib3k ... done
Successfully installed feedparser-5.2.1 sgmllib3k-1.0.0
```