### PR TITLE
Unbreak feedparser.SANITIZE_HTML

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 coming in the next release:
     * Support Python 3.5
     * Convert feedparser from a monolithic file to a package
+         * The ``feedparser.SANITIZE_HTML`` flag has moved to ``feedparser.api.SANITIZE_HTML``.
     * Unify the codebase so that 2to3 conversion is no longer required
     * Remove references to iconv_codecs
     * Update the Creative Commons namespace URI's

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,8 @@
 coming in the next release:
     * Support Python 3.5
     * Convert feedparser from a monolithic file to a package
-         * The ``feedparser.SANITIZE_HTML`` flag has moved to ``feedparser.api.SANITIZE_HTML``.
+    * ``feedparser.parse(sanitize_html=bool)`` argument replaces the ``feedparser.SANITIZE_HTML`` global
+    * ``feedparser.parse(resolve_relative_uris=bool)`` replaces the ``feedparser.RESOLVE_RELATIVE_URIS`` global
     * Unify the codebase so that 2to3 conversion is no longer required
     * Remove references to iconv_codecs
     * Update the Creative Commons namespace URI's

--- a/docs/html-sanitization.rst
+++ b/docs/html-sanitization.rst
@@ -809,6 +809,13 @@ attributes that I have not explicitly investigated. And I have no confidence at
 all in my ability to detect strings within attribute values that Internet
 Explorer for Windows will treat as executable code.
 
+Disabling HTML Sanitization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Though not recommended, it is possible to disable :program:`Universal Feed Parser`\'s
+HTML sanitization by passing ``sanitize_html=False`` to :func:`feedparser.parse()`.
+When passing this flag you are responsible for manually sanitizing HTML from the feed.
+
 .. seealso::
 
     `How to consume RSS safely <http://diveintomark.org/archives/2003/06/12/how_to_consume_rss_safely>`_

--- a/docs/resolving-relative-links.rst
+++ b/docs/resolving-relative-links.rst
@@ -245,7 +245,9 @@ Disabling Relative :abbr:`URI (Uniform Resource Identifier)`\s Resolution
 -------------------------------------------------------------------------
 
 Though not recommended, it is possible to disable :program:`Universal Feed Parser`\'s relative
-:abbr:`URI (Uniform Resource Identifier)` resolution by setting feedparser.RESOLVE_RELATIVE_URIS to ``0``.
+:abbr:`URI (Uniform Resource Identifier)` resolution by passing ``resolve_relative_uris=False``
+to :func:`feedparser.parse()`. This disables resolution within HTML content,
+but not in other contexts such as :ref:`reference.entry.link`.
 
 
 How to disable relative :abbr:`URI (Uniform Resource Identifier)` resolution

--- a/feedparser/__init__.py
+++ b/feedparser/__init__.py
@@ -41,4 +41,10 @@ from .api import parse
 from .datetimes import registerDateHandler
 from .exceptions import *
 
-api.USER_AGENT = USER_AGENT
+# If you want feedparser to automatically resolve all relative URIs, set this
+# to 1.
+RESOLVE_RELATIVE_URIS = 1
+
+# If you want feedparser to automatically sanitize all potentially unsafe
+# HTML content, set this to 1.
+SANITIZE_HTML = 1

--- a/feedparser/api.py
+++ b/feedparser/api.py
@@ -75,17 +75,7 @@ except NameError:
 # of pre-installed parsers until it finds one that supports everything we need.
 PREFERRED_XML_PARSERS = ["drv_libxml2"]
 
-# If you want feedparser to automatically resolve all relative URIs, set this
-# to 1.
-RESOLVE_RELATIVE_URIS = 1
-
-# If you want feedparser to automatically sanitize all potentially unsafe
-# HTML content, set this to 1.
-SANITIZE_HTML = 1
-
 _XML_AVAILABLE = True
-mixin.RESOLVE_RELATIVE_URIS = RESOLVE_RELATIVE_URIS
-mixin.SANITIZE_HTML = SANITIZE_HTML
 
 SUPPORTED_VERSIONS = {
     '': 'unknown',
@@ -175,17 +165,58 @@ StrictFeedParser = type(str('StrictFeedParser'), (
     _StrictFeedParser, _FeedParserMixin, xml.sax.handler.ContentHandler, object
 ), {})
 
-def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, response_headers=None):
+def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, referrer=None, handlers=None, request_headers=None, response_headers=None, resolve_relative_uris=None, sanitize_html=None):
     '''Parse a feed from a URL, file, stream, or string.
 
-    request_headers, if given, is a dict from http header name to value to add
-    to the request; this overrides internally generated values.
+    :param url_file_stream_or_string:
+        File-like object, URL, file path, or string. Both byte and text strings
+        are accepted. If necessary, encoding will be derived from the response
+        headers or automatically detected.
+
+        Note that strings may trigger network I/O or filesystem access
+        depending on the value. Wrap an untrusted string in
+        a :class:`io.StringIO` or :class:`io.BytesIO` to avoid this. Do not
+        pass untrusted strings to this function.
+
+        When a URL is not passed the feed location to use in relative URL
+        resolution should be passed in the ``Content-Location`` response header
+        (see ``response_headers`` below).
+
+    :param str etag: HTTP ``ETag`` request header.
+    :param str modified: HTTP ``Last-Modified`` request header.
+    :param str agent: HTTP ``User-Agent`` request header, which defaults to
+        the value of :data:`feedparser.USER_AGENT`.
+    :param referrer: HTTP ``Referer`` [sic] request header.
+    :param request_headers:
+        A mapping of HTTP header name to HTTP header value to add to the
+        request, overriding internally generated values.
+    :type request_headers: :class:`dict` mapping :class:`str` to :class:`str`
+    :param response_headers:
+        A mapping of HTTP header name to HTTP header value. Multiple values may
+        be joined with a comma. If a HTTP request was made, these headers
+        override any matching headers in the response. Otherwise this specifies
+        the entirety of the response headers.
+    :type response_headers: :class:`dict` mapping :class:`str` to :class:`str`
+
+    :param bool resolve_relative_uris:
+        Should feedparser attempt to resolve relative URIs in the feed to absolute ones?
+        Defaults to the value of :data:`feedparser.RESOLVE_RELATIVE_URIS`, which is ``True``.
+    :param bool sanitize_html:
+        Should feedparser skip HTML sanitization? Only disable this if you know
+        what you are doing!  Defaults to the value of
+        :data:`feedparser.SANITIZE_HTML`, which is ``True``.
 
     :return: A :class:`FeedParserDict`.
     '''
-
+    if not agent or sanitize_html is None or resolve_relative_uris is None:
+        import feedparser
     if not agent:
-        agent = USER_AGENT
+        agent = feedparser.USER_AGENT
+    if sanitize_html is None:
+        sanitize_html = feedparser.SANITIZE_HTML
+    if resolve_relative_uris is None:
+        resolve_relative_uris = feedparser.RESOLVE_RELATIVE_URIS
+
     result = FeedParserDict(
         bozo = False,
         entries = [],
@@ -220,6 +251,8 @@ def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, refer
     if use_strict_parser:
         # initialize the SAX parser
         feedparser = StrictFeedParser(baseuri, baselang, 'utf-8')
+        feedparser.resolve_relative_uris = resolve_relative_uris
+        feedparser.sanitize_html = sanitize_html
         saxparser = xml.sax.make_parser(PREFERRED_XML_PARSERS)
         saxparser.setFeature(xml.sax.handler.feature_namespaces, 1)
         try:
@@ -239,6 +272,8 @@ def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, refer
             use_strict_parser = 0
     if not use_strict_parser and _SGML_AVAILABLE:
         feedparser = LooseFeedParser(baseuri, baselang, 'utf-8', entities)
+        feedparser.resolve_relative_uris = resolve_relative_uris
+        feedparser.sanitize_html = sanitize_html
         feedparser.feed(data.decode('utf-8', 'replace'))
     result['feed'] = feedparser.feeddata
     result['entries'] = feedparser.entries

--- a/feedparser/api.py
+++ b/feedparser/api.py
@@ -201,8 +201,9 @@ def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, refer
     :type response_headers: :class:`dict` mapping :class:`str` to :class:`str`
 
     :param bool resolve_relative_uris:
-        Should feedparser attempt to resolve relative URIs in the feed to absolute ones?
-        Defaults to the value of :data:`feedparser.RESOLVE_RELATIVE_URIS`, which is ``True``.
+        Should feedparser attempt to resolve relative URIs absolute ones within
+        HTML content?  Defaults to the value of
+        :data:`feedparser.RESOLVE_RELATIVE_URIS`, which is ``True``.
     :param bool sanitize_html:
         Should feedparser skip HTML sanitization? Only disable this if you know
         what you are doing!  Defaults to the value of

--- a/feedparser/api.py
+++ b/feedparser/api.py
@@ -183,7 +183,9 @@ def parse(url_file_stream_or_string, etag=None, modified=None, agent=None, refer
         (see ``response_headers`` below).
 
     :param str etag: HTTP ``ETag`` request header.
-    :param str modified: HTTP ``Last-Modified`` request header.
+    :param modified: HTTP ``Last-Modified`` request header.
+    :type modified: :class:`str`, :class:`time.struct_time` 9-tuple, or
+        :class:`datetime.datetime`
     :param str agent: HTTP ``User-Agent`` request header, which defaults to
         the value of :data:`feedparser.USER_AGENT`.
     :param referrer: HTTP ``Referer`` [sic] request header.

--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -515,12 +515,12 @@ class _FeedParserMixin(
 
         is_htmlish = self.mapContentType(self.contentparams.get('type', 'text/html')) in self.html_types
         # resolve relative URIs within embedded markup
-        if is_htmlish and RESOLVE_RELATIVE_URIS:
+        if is_htmlish and self.resolve_relative_uris:
             if element in self.can_contain_relative_uris:
                 output = _resolveRelativeURIs(output, self.baseuri, self.encoding, self.contentparams.get('type', 'text/html'))
 
         # sanitize embedded markup
-        if is_htmlish and SANITIZE_HTML:
+        if is_htmlish and self.sanitize_html:
             if element in self.can_contain_dangerous_markup:
                 output = _sanitizeHTML(output, self.encoding, self.contentparams.get('type', 'text/html'))
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -31,7 +31,6 @@ __license__ = "BSD 2-clause"
 import codecs
 import datetime
 import glob
-import operator
 import os
 import posixpath
 import pprint

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -31,6 +31,7 @@ __license__ = "BSD 2-clause"
 import codecs
 import datetime
 import glob
+import io
 import os
 import posixpath
 import pprint
@@ -689,6 +690,50 @@ class TestLxmlBug(unittest.TestCase):
             feedparser.parse(feedparser.api._StringIO(doc))
         self.assertTrue(True)
 
+
+class TestParseFlags(unittest.TestCase):
+    feed_xml = b"""
+        <rss version="2.0">
+            <channel>
+                <item>
+                    <body><script>alert("boo!")</script></body>
+                </item>
+                <item>
+                    <body><a href="/boo.html">boo</a></body>
+                </item>
+            </channel>
+        </rss>
+    """
+    def test_sanitize_html_default(self):
+        d = feedparser.parse(io.BytesIO(self.feed_xml))
+        self.assertEqual(u'', d.entries[0].content[0].value)
+
+    def test_sanitize_html_on(self):
+        d = feedparser.parse(io.BytesIO(self.feed_xml), sanitize_html=True)
+        self.assertEqual(u'', d.entries[0].content[0].value)
+
+    def test_sanitize_html_off(self):
+        d = feedparser.parse(io.BytesIO(self.feed_xml), sanitize_html=False)
+        self.assertEqual(u'<script>alert("boo!")</script>', d.entries[0].content[0].value)
+
+    def test_resolve_relative_uris_default(self):
+        d = feedparser.parse(io.BytesIO(self.feed_xml),
+                             response_headers={'content-location': 'http://example.com/feed'})
+        self.assertEqual(u'<a href="http://example.com/boo.html">boo</a>', d.entries[1].content[0].value)
+
+    def test_resolve_relative_uris_on(self):
+        d = feedparser.parse(io.BytesIO(self.feed_xml),
+                             response_headers={'content-location': 'http://example.com/feed'},
+                             resolve_relative_uris=True)
+        self.assertEqual(u'<a href="http://example.com/boo.html">boo</a>', d.entries[1].content[0].value)
+
+    def test_resolve_relative_uris_off(self):
+        d = feedparser.parse(io.BytesIO(self.feed_xml),
+                             response_headers={'content-location': 'http://example.com/feed.xml'},
+                             resolve_relative_uris=False)
+        self.assertEqual(u'<a href="/boo.html">boo</a>', d.entries[1].content[0].value)
+
+
 #---------- parse test files and create test methods ----------
 def convert_to_utf8(data):
     "Identify data's encoding using its byte order mark" \
@@ -825,6 +870,7 @@ def runtests():
     testsuite.addTest(testloader.loadTestsFromTestCase(TestEverythingIsUnicode))
     testsuite.addTest(testloader.loadTestsFromTestCase(TestTemporaryFallbackBehavior))
     testsuite.addTest(testloader.loadTestsFromTestCase(TestLxmlBug))
+    testsuite.addTest(testloader.loadTestsFromTestCase(TestParseFlags))
     testresults = unittest.TextTestRunner(verbosity=1).run(testsuite)
 
     # Return 0 if successful, 1 if there was a failure


### PR DESCRIPTION
The relocation of `feedparser.SANITIZE_HTML` to `feedparser.api.SANITIZE_HTML` made it really awkward to override. Because the flag is copied into `feedparser.mixin`, one would have to patch it there after importing `feedparser.api`, e.g.,:

```python
import feedparser.api
feedparser.mixin.SANITIZE_HTML = False
```

This PR restores the functionality of setting `feedparser.USER_AGENT`, `feedparser.SANITIZE_HTML`, and `feedparser.RESOLVE_RELATIVE_URIS`. Because assigning to global constants is a pretty awkward API, it also adds `feedparser.parse(sanitize_html=bool, resolve_relative_uris=bool)` arguments.

Unit tests and documentation updates are included.