### PR TITLE
Remove "DeprecationWarning: invalid escape sequence" in Python 3.6.

### DIFF
--- a/feedparser/datetimes/greek.py
+++ b/feedparser/datetimes/greek.py
@@ -40,7 +40,7 @@ _greek_wdays = \
   }
 
 _greek_date_format_re = \
-    re.compile('([^,]+),\s+(\d{2})\s+([^\s]+)\s+(\d{4})\s+(\d{2}):(\d{2}):(\d{2})\s+([^\s]+)')
+    re.compile(r'([^,]+),\s+(\d{2})\s+([^\s]+)\s+(\d{4})\s+(\d{2}):(\d{2}):(\d{2})\s+([^\s]+)')
 
 def _parse_date_greek(dateString):
     '''Parse a string according to a Greek 8-bit date format.'''

--- a/feedparser/datetimes/hungarian.py
+++ b/feedparser/datetimes/hungarian.py
@@ -22,7 +22,7 @@ _hungarian_months = \
   }
 
 _hungarian_date_format_re = \
-  re.compile('(\d{4})-([^-]+)-(\d{,2})T(\d{,2}):(\d{2})((\+|-)(\d{,2}:\d{2}))')
+  re.compile(r'(\d{4})-([^-]+)-(\d{,2})T(\d{,2}):(\d{2})((\+|-)(\d{,2}:\d{2}))')
 
 def _parse_date_hungarian(dateString):
     '''Parse a string according to a Hungarian 8-bit date format.'''

--- a/feedparser/datetimes/korean.py
+++ b/feedparser/datetimes/korean.py
@@ -12,10 +12,10 @@ _korean_am    = '\uc624\uc804' # bfc0 c0fc in euc-kr
 _korean_pm    = '\uc624\ud6c4' # bfc0 c8c4 in euc-kr
 
 _korean_onblog_date_re = \
-    re.compile('(\d{4})%s\s+(\d{2})%s\s+(\d{2})%s\s+(\d{2}):(\d{2}):(\d{2})' % \
+    re.compile(r'(\d{4})%s\s+(\d{2})%s\s+(\d{2})%s\s+(\d{2}):(\d{2}):(\d{2})' % \
                (_korean_year, _korean_month, _korean_day))
 _korean_nate_date_re = \
-    re.compile('(\d{4})-(\d{2})-(\d{2})\s+(%s|%s)\s+(\d{,2}):(\d{,2}):(\d{,2})' % \
+    re.compile(r'(\d{4})-(\d{2})-(\d{2})\s+(%s|%s)\s+(\d{,2}):(\d{,2}):(\d{,2})' % \
                (_korean_am, _korean_pm))
 def _parse_date_onblog(dateString):
     '''Parse a string according to the OnBlog 8-bit date format'''

--- a/feedparser/encodings.py
+++ b/feedparser/encodings.py
@@ -69,11 +69,11 @@ ZERO_BYTES = '\x00\x00'
 
 # Match the opening XML declaration.
 # Example: <?xml version="1.0" encoding="utf-8"?>
-RE_XML_DECLARATION = re.compile('^<\?xml[^>]*?>')
+RE_XML_DECLARATION = re.compile(r'^<\?xml[^>]*?>')
 
 # Capture the value of the XML processing instruction's encoding attribute.
 # Example: <?xml version="1.0" encoding="utf-8"?>
-RE_XML_PI_ENCODING = re.compile(b'^<\?.*encoding=[\'"](.*?)[\'"].*\?>')
+RE_XML_PI_ENCODING = re.compile(br'^<\?.*encoding=[\'"](.*?)[\'"].*\?>')
 
 def convert_to_utf8(http_headers, data, result):
     '''Detect and convert the character encoding to UTF-8.

--- a/feedparser/html.py
+++ b/feedparser/html.py
@@ -41,7 +41,7 @@ _cp1252 = {
 
 class _BaseHTMLProcessor(sgmllib.SGMLParser, object):
     special = re.compile('''[<>'"]''')
-    bare_ampersand = re.compile("&(?!#\d+;|#x[0-9a-fA-F]+;|\w+;)")
+    bare_ampersand = re.compile(r"&(?!#\d+;|#x[0-9a-fA-F]+;|\w+;)")
     elements_no_end_tag = set([
       'area', 'base', 'basefont', 'br', 'col', 'command', 'embed', 'frame',
       'hr', 'img', 'input', 'isindex', 'keygen', 'link', 'meta', 'param',

--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -559,7 +559,7 @@ class _FeedParserMixin(
                     # converted from `?a=1&b=2` to `?a=1&b;=2` as if they're
                     # unhandled character references. fix this special case.
                     output = output.replace('&amp;', '&')
-                    output = re.sub("&([A-Za-z0-9_]+);", "&\g<1>", output)
+                    output = re.sub("&([A-Za-z0-9_]+);", r"&\g<1>", output)
                     self.entries[-1][element] = output
                     if output:
                         self.entries[-1]['links'][-1]['href'] = output
@@ -581,7 +581,7 @@ class _FeedParserMixin(
             context[element] = output
             if element == 'link':
                 # fix query variables; see above for the explanation
-                output = re.sub("&([A-Za-z0-9_]+);", "&\g<1>", output)
+                output = re.sub("&([A-Za-z0-9_]+);", r"&\g<1>", output)
                 context[element] = output
                 context['links'][-1]['href'] = output
             elif self.incontent:

--- a/feedparser/sanitizer.py
+++ b/feedparser/sanitizer.py
@@ -66,8 +66,8 @@ class _HTMLSanitizer(_BaseHTMLProcessor):
       'pointer', 'purple', 'red', 'right', 'solid', 'silver', 'teal', 'top',
       'transparent', 'underline', 'white', 'yellow'])
 
-    valid_css_values = re.compile('^(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|' +
-      '\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)$')
+    valid_css_values = re.compile(r'^(#[0-9a-f]+|rgb\(\d+%?,\d*%?,?\d*%?\)?|' +
+      r'\d{0,2}\.?\d{0,2}(cm|em|ex|in|mm|pc|pt|px|%|,|\))?)$')
 
     mathml_elements = set([
         'annotation',
@@ -358,17 +358,17 @@ class _HTMLSanitizer(_BaseHTMLProcessor):
 
     def sanitize_style(self, style):
         # disallow urls
-        style=re.compile('url\s*\(\s*[^\s)]+?\s*\)\s*').sub(' ',style)
+        style=re.compile(r'url\s*\(\s*[^\s)]+?\s*\)\s*').sub(' ',style)
 
         # gauntlet
-        if not re.match("""^([:,;#%.\sa-zA-Z0-9!]|\w-\w|'[\s\w]+'|"[\s\w]+"|\([\d,\s]+\))*$""", style):
+        if not re.match(r"""^([:,;#%.\sa-zA-Z0-9!]|\w-\w|'[\s\w]+'|"[\s\w]+"|\([\d,\s]+\))*$""", style):
             return ''
         # This replaced a regexp that used re.match and was prone to pathological back-tracking.
-        if re.sub("\s*[-\w]+\s*:\s*[^:;]*;?", '', style).strip():
+        if re.sub(r"\s*[-\w]+\s*:\s*[^:;]*;?", '', style).strip():
             return ''
 
         clean = []
-        for prop,value in re.findall("([-\w]+)\s*:\s*([^:;]*)",style):
+        for prop,value in re.findall(r"([-\w]+)\s*:\s*([^:;]*)",style):
             if not value:
                 continue
             if prop.lower() in self.acceptable_css_properties:
@@ -422,7 +422,7 @@ RE_DOCTYPE_PATTERN = re.compile(br'^\s*<!DOCTYPE([^>]*?)>', re.MULTILINE)
 # Example: cubed "&#179;"
 # Example: copyright "(C)"
 # Forbidden: explode1 "&explode2;&explode2;"
-RE_SAFE_ENTITY_PATTERN = re.compile(b'\s+(\w+)\s+"(&#\w+;|[^&"]*)"')
+RE_SAFE_ENTITY_PATTERN = re.compile(br'\s+(\w+)\s+"(&#\w+;|[^&"]*)"')
 
 def replace_doctype(data):
     '''Strips and replaces the DOCTYPE, returns (rss_version, stripped_data)
@@ -433,7 +433,7 @@ def replace_doctype(data):
 
     # Divide the document into two groups by finding the location
     # of the first element that doesn't begin with '<?' or '<!'.
-    start = re.search(b'<\w', data)
+    start = re.search(br'<\w', data)
     start = start and start.start() or -1
     head, data = data[:start+1], data[start+1:]
 

--- a/feedparser/sgml.py
+++ b/feedparser/sgml.py
@@ -41,8 +41,8 @@ else:
     # names, and the compiled code objects of several sgmllib.SGMLParser
     # methods are copied into _BaseHTMLProcessor so that they execute in
     # feedparser's scope instead of sgmllib's scope.
-    charref = re.compile('&#(\d+|[xX][0-9a-fA-F]+);')
-    tagfind = re.compile('[a-zA-Z][-_.:a-zA-Z0-9]*')
+    charref = re.compile(r'&#(\d+|[xX][0-9a-fA-F]+);')
+    tagfind = re.compile(r'[a-zA-Z][-_.:a-zA-Z0-9]*')
     attrfind = re.compile(
         r'\s*([a-zA-Z_][-:.a-zA-Z_0-9]*)[$]?(\s*=\s*'
         r'(\'[^\']*\'|"[^"]*"|[][\-a-zA-Z0-9./,:;+*%?!&$\(\)_#=~\'"@]*))?'
@@ -60,7 +60,7 @@ else:
         def __init__(self):
             # Overriding the built-in sgmllib.endbracket regex allows the
             # parser to find angle brackets embedded in element attributes.
-            self.endbracket = re.compile('''([^'"<>]|"[^"]*"(?=>|/|\s|\w+=)|'[^']*'(?=>|/|\s|\w+=))*(?=[<>])|.*?(?=[<>])''')
+            self.endbracket = re.compile(r'''([^'"<>]|"[^"]*"(?=>|/|\s|\w+=)|'[^']*'(?=>|/|\s|\w+=))*(?=[<>])|.*?(?=[<>])''')
         def search(self, target, index=0):
             match = self.endbracket.match(target, index)
             if match is not None:


### PR DESCRIPTION
Just add a "r" prefix to some strings to remove the  "DeprecationWarning: invalid escape sequence" warnings that appear in Python 3.6.