### PR TITLE
Replace dead links to diveintomark.org

### DIFF
--- a/docs/changes-early.rst
+++ b/docs/changes-early.rst
@@ -31,7 +31,7 @@ Changes in earlier versions
 
 - removed unnecessary :file:`>urllib` code -- :file:`urllib2` should always be available anyway
 
-- return actual ``url``, ``status``, and full :abbr:`HTTP (Hypertext Transfer Protocol)` headers (as ``result['url']``, ``result['status']``, and ``result['headers']``) if parsing a remote feed over :abbr:`HTTP (Hypertext Transfer Protocol)`.  This should pass all the `Aggregator client :abbr:`HTTP (Hypertext Transfer Protocol)` tests <http://diveintomark.org/tests/client/http/>`_.
+- return actual ``url``, ``status``, and full :abbr:`HTTP (Hypertext Transfer Protocol)` headers (as ``result['url']``, ``result['status']``, and ``result['headers']``) if parsing a remote feed over :abbr:`HTTP (Hypertext Transfer Protocol)`.  This should pass all the `Aggregator client :abbr:`HTTP (Hypertext Transfer Protocol)` tests <https://web.archive.org/web/20110404234421/http://diveintomark.org/tests/client/http/>`_.
 
 - added the latest namespace-of-the-week for :abbr:`RSS (Rich Site Summary)` 2.0
 
@@ -104,7 +104,7 @@ Changes in earlier versions
 
 :program:`Ultra-liberal RSS Parser` was first released on August 13, 2002.
 
-`Announcement <http://diveintomark.org/archives/2002/08/13/ultraliberal_rss_parser>`_:
+`Announcement <https://web.archive.org/web/20110424133115/http://diveintomark.org/archives/2002/08/13/ultraliberal_rss_parser>`_:
 
     Aaron Swartz has been looking for an ultra-liberal :abbr:`RSS (Rich Site Summary)` parser. Now that I'm experimenting with a homegrown :abbr:`RSS (Rich Site Summary)`-to-email news aggregator, so am I. You see, most :abbr:`RSS (Rich Site Summary)` feeds suck. Invalid characters, unescaped ampersands (Blogger feeds), invalid entities (Radio feeds), unescaped and invalid HTML (The Register's feed most days). Or just a bastardized mix of :abbr:`RSS (Rich Site Summary)` 0.9x elements with :abbr:`RSS (Rich Site Summary)` 1.0 elements (Movable Type feeds).
 

--- a/docs/html-sanitization.rst
+++ b/docs/html-sanitization.rst
@@ -714,7 +714,7 @@ default in style attributes (all others are stripped):
     Not all possible CSS values are allowed for these properties.  The
     allowable values are restricted by a whitelist and a regular expression that
     allows color values and lengths.  :abbr:`URI (Uniform Resource Identifier)`\s
-    are not allowed, to prevent `platypus attacks <http://diveintomark.org/archives/2003/06/12/how_to_consume_rss_safely>`_.
+    are not allowed, to prevent `platypus attacks <https://web.archive.org/web/20080826033749/http://diveintomark.org/archives/2003/06/12/how_to_consume_rss_safely>`_.
     See the _HTMLSanitizer class for more details.
 
 
@@ -818,5 +818,5 @@ When passing this flag you are responsible for manually sanitizing HTML from the
 
 .. seealso::
 
-    `How to consume RSS safely <http://diveintomark.org/archives/2003/06/12/how_to_consume_rss_safely>`_
+    `How to consume RSS safely <https://web.archive.org/web/20080826033749/http://diveintomark.org/archives/2003/06/12/how_to_consume_rss_safely>`_
         Explains the platypus attack.

--- a/docs/version-detection.rst
+++ b/docs/version-detection.rst
@@ -37,7 +37,7 @@ Here is the complete list of known feed types and versions that may be returned 
     `Netscape RSS 0.91 <http://my.netscape.com/publish/formats/rss-spec-0.91.html>`_
 
 ``rss091u``
-    `Userland RSS 0.91 <http://backend.userland.com/rss091>`_ (`differences from Netscape RSS 0.91 <http://diveintomark.org/archives/2004/02/04/incompatible-rss#example3>`_)
+    `Userland RSS 0.91 <http://backend.userland.com/rss091>`_ (`differences from Netscape RSS 0.91 <https://web.archive.org/web/20110927015220/http://diveintomark.org/archives/2004/02/04/incompatible-rss#example3>`_)
 
 ``rss10``
     `RSS 1.0 <http://purl.org/rss/1.0/>`_
@@ -61,7 +61,7 @@ Here is the complete list of known feed types and versions that may be returned 
     `Atom 0.1 <http://www.intertwingly.net/blog/1506.html>`_
 
 ``atom02``
-    `Atom 0.2 <http://diveintomark.org/public/2003/08/atom02spec.txt>`_
+    `Atom 0.2 <https://web.archive.org/web/20080612041743/http://diveintomark.org/public/2003/08/atom02spec.txt>`_
 
 ``atom03``
     `Atom 0.3 <http://www.mnot.net/drafts/draft-nottingham-atom-format-02.html>`_


### PR DESCRIPTION
There are a few more in the annotated examples and NEWS file, but the links aren't important for the examples, and I wasn't sure if modifying the older items in the changelog might break something that expects them to stay the same.