### PR TITLE
Fix error with Python3.7 now PEP479 is enforced.

### DIFF
--- a/feedparser/namespaces/georss.py
+++ b/feedparser/namespaces/georss.py
@@ -175,12 +175,15 @@ def _parse_poslist(value, geom_type, swap=True, dims=2):
 def _gen_georss_coords(value, swap=True, dims=2):
     # A generator of (lon, lat) pairs from a string of encoded GeoRSS
     # coordinates. Converts to floats and swaps order.
-    latlons = (float(ll) for ll in value.replace(',', ' ').split())
+    latlons = ( float(ll) for ll in value.replace(',', ' ').split() )
     while True:
-        t = [next(latlons), next(latlons)][::swap and -1 or 1]
-        if dims == 3:
-            t.append(next(latlons))
-        yield tuple(t)
+        try:
+            t = [next(latlons), next(latlons)][::swap and -1 or 1]
+            if dims == 3:
+                t.append(next(latlons))
+            yield tuple(t)
+        except StopIteration:
+            return
 
 def _parse_georss_point(value, swap=True, dims=2):
     # A point contains a single latitude-longitude pair, separated by

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, py37
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
 - Change _gen_georss_coords to capture StopIteration
   from value list, using pattern from PEP

Fixes #130