### PR TITLE
Travis support for automated builds including Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+sudo: false
+
+matrix:
+  fast_finish: true
+  include:
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: "3.7"
+      env: TOXENV=py37
+      dist: xenial
+      sudo: true
+
+install: pip install -U tox coveralls
+script: travis_wait 30 tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ sudo: false
 matrix:
   fast_finish: true
   include:
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.7"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, py37
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This PR adds a simple Travis CI configuration file that includes tox build configs for
* Python 2.7
* Python 3.4
* Python 3.5
* Python 3.6
* Python 3.7

Of course, at this point in time, only the first 4 variants will run successfully, the Python 3.7 tox build will fail until https://github.com/kurtmckee/feedparser/pull/131 is merged.

Once merged, please sign up for an account at https://travis-ci.org/, link your GitHub account, add this repository, and Travis CI will automatically build the project at each commit.