### PR TITLE
TLS Negotiation and Astral Plane characters

### DIFF
--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -11,6 +11,7 @@ import certifi
 try:
     import urllib.parse
     import urllib.request
+    from urllib.request import HTTPSHandler
 except ImportError:
     from urllib import splithost, splittype, splituser
     from urllib2 import build_opener, HTTPSHandler, HTTPDigestAuthHandler, HTTPRedirectHandler, HTTPDefaultErrorHandler, Request

--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -13,7 +13,7 @@ try:
     import urllib.request
 except ImportError:
     from urllib import splithost, splittype, splituser
-    from urllib2 import install_opener, build_opener, HTTPSHandler, HTTPDigestAuthHandler, HTTPRedirectHandler, HTTPDefaultErrorHandler, Request
+    from urllib2 import build_opener, HTTPSHandler, HTTPDigestAuthHandler, HTTPRedirectHandler, HTTPDefaultErrorHandler, Request
     from urlparse import urlparse
 
     class urllib(object):

--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -5,13 +5,15 @@ import gzip
 import re
 import struct
 import zlib
+import ssl
 
 try:
+    import certifi
     import urllib.parse
     import urllib.request
 except ImportError:
     from urllib import splithost, splittype, splituser
-    from urllib2 import build_opener, HTTPDigestAuthHandler, HTTPRedirectHandler, HTTPDefaultErrorHandler, Request
+    from urllib2 import install_opener, urlopen, build_opener, HTTPDigestAuthHandler, HTTPRedirectHandler, HTTPDefaultErrorHandler, Request
     from urlparse import urlparse
 
     class urllib(object):
@@ -172,7 +174,10 @@ def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None,
     request = _build_urllib2_request(url, agent, ACCEPT_HEADER, etag, modified, referrer, auth, request_headers)
     opener = urllib.request.build_opener(*tuple(handlers + [_FeedURLHandler()]))
     opener.addheaders = [] # RMK - must clear so we only send our custom User-Agent
-    f = opener.open(request)
+    install_opener(opener)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+    context.load_verify_locations(cafile=certifi.where())
+    f = urlopen(request, context=context)
     data = f.read()
     f.close()
 

--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -13,7 +13,7 @@ try:
     import urllib.request
 except ImportError:
     from urllib import splithost, splittype, splituser
-    from urllib2 import install_opener, urlopen, build_opener, HTTPDigestAuthHandler, HTTPRedirectHandler, HTTPDefaultErrorHandler, Request
+    from urllib2 import install_opener, build_opener, HTTPSHandler, HTTPDigestAuthHandler, HTTPRedirectHandler, HTTPDefaultErrorHandler, Request
     from urlparse import urlparse
 
     class urllib(object):
@@ -172,12 +172,11 @@ def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None,
 
     # try to open with urllib2 (to use optional headers)
     request = _build_urllib2_request(url, agent, ACCEPT_HEADER, etag, modified, referrer, auth, request_headers)
-    opener = urllib.request.build_opener(*tuple(handlers + [_FeedURLHandler()]))
-    opener.addheaders = [] # RMK - must clear so we only send our custom User-Agent
-    install_opener(opener)
     context = ssl.SSLContext(ssl.PROTOCOL_TLS)
     context.load_verify_locations(cafile=certifi.where())
-    f = urlopen(request, context=context)
+    opener = urllib.request.build_opener(*tuple(handlers + [HTTPSHandler(context=context)] + [_FeedURLHandler()]))
+    opener.addheaders = [] # RMK - must clear so we only send our custom User-Agent
+    f = opener.open(request)
     data = f.read()
     f.close()
 

--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -6,9 +6,9 @@ import re
 import struct
 import zlib
 import ssl
+import certifi
 
 try:
-    import certifi
     import urllib.parse
     import urllib.request
 except ImportError:

--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -324,7 +324,7 @@ class _FeedParserMixin(
 
     def unichar(self, i):
         try:
-            return unichr(i)
+            return chr(i)
         except ValueError:
             return struct.pack('i', i).decode('utf-32')
 

--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -177,6 +177,7 @@ class _FeedParserMixin(
         self.svgOK = 0
         self.title_depth = -1
         self.depth = 0
+        self.hasContent = 0
         if self.lang:
             self.feeddata['language'] = self.lang.replace('_','-')
 

--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -360,7 +360,7 @@ class _FeedParserMixin(
             except KeyError:
                 text = '&%s;' % ref
             else:
-                text = chr(name2codepoint[ref]).encode('utf-8')
+                text = self.unichar(name2codepoint[ref]).encode('utf-8')
         self.elementstack[-1][2].append(text)
 
     def handle_data(self, text, escape=1):

--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import, unicode_literals
 
 import copy
 import re
+import struct
 
 from xml.sax.saxutils import escape as _xmlescape
 
@@ -321,6 +322,12 @@ class _FeedParserMixin(
 
         self.depth -= 1
 
+    def unichar(self, i):
+        try:
+            return unichr(i)
+        except ValueError:
+            return struct.pack('i', i).decode('utf-32')
+
     def handle_charref(self, ref):
         # called for each character reference, e.g. for '&#160;', ref will be '160'
         if not self.elementstack:
@@ -333,7 +340,7 @@ class _FeedParserMixin(
                 c = int(ref[1:], 16)
             else:
                 c = int(ref)
-            text = chr(c).encode('utf-8')
+            text = self.unichar(c).encode('utf-8')
         self.elementstack[-1][2].append(text)
 
     def handle_entityref(self, ref):

--- a/feedparser/namespaces/_base.py
+++ b/feedparser/namespaces/_base.py
@@ -257,6 +257,7 @@ class Namespace(object):
     def _end_item(self):
         self.pop('item')
         self.inentry = 0
+        self.hasContent = 0
     _end_entry = _end_item
 
     def _start_language(self, attrsD):
@@ -384,7 +385,7 @@ class Namespace(object):
 
     def _start_description(self, attrsD):
         context = self._getContext()
-        if 'summary' in context:
+        if 'summary' in context and not self.hasContent:
             self._summaryKey = 'content'
             self._start_content(attrsD)
         else:
@@ -425,7 +426,7 @@ class Namespace(object):
 
     def _start_summary(self, attrsD):
         context = self._getContext()
-        if 'summary' in context:
+        if 'summary' in context and not self.hasContent:
             self._summaryKey = 'content'
             self._start_content(attrsD)
         else:
@@ -462,6 +463,7 @@ class Namespace(object):
         self.sourcedata.clear()
 
     def _start_content(self, attrsD):
+        self.hasContent = 1
         self.pushContent('content', attrsD, 'text/plain', 1)
         src = attrsD.get('src')
         if src:
@@ -473,6 +475,7 @@ class Namespace(object):
     _start_xhtml_body = _start_body
 
     def _start_content_encoded(self, attrsD):
+        self.hasContent = 1
         self.pushContent('content', attrsD, 'text/html', 1)
     _start_fullitem = _start_content_encoded
 

--- a/feedparser/sanitizer.py
+++ b/feedparser/sanitizer.py
@@ -129,6 +129,7 @@ class _HTMLSanitizer(_BaseHTMLProcessor):
         'alttext',
         'bevelled',
         'charalign',
+        'class',
         'close',
         'columnalign',
         'columnlines',

--- a/tests/entities/doublestruck.xml
+++ b/tests/entities/doublestruck.xml
@@ -1,0 +1,9 @@
+<!--
+Description: Double-struck X
+Expect:      feed['title'] == 'testing \U0001d54f entity'
+-->
+<rss>
+<channel>
+<title>testing &#x1d54f; entity</title>
+</channel>
+</rss>

--- a/tests/wellformed/atom10/entry_content_and_summary.xml
+++ b/tests/wellformed/atom10/entry_content_and_summary.xml
@@ -1,0 +1,10 @@
+<!--
+Description: entry summary follows content with different value
+Expect:      not bozo and entries[0]['summary'] == 'Summary'
+-->
+<feed xmlns="http://www.w3.org/2005/Atom">
+<entry>
+  <content>Example Atom</content>
+  <summary>Summary</summary>
+</entry>
+</feed>


### PR DESCRIPTION
Two fixes here:

1. Convince `urllib2` to negotiate the most secure SSL connection that client and server support. The current version [defaults to TLSv1.0](https://golem.ph.utexas.edu/~distler/blog/archives/003080.html). Many sites have dropped (or are planning to drop) TLSv1.0.
2. Support Astral Plane characters in narrow Python builds.