### PR TITLE
Use callable instead of isinstance Callable

### DIFF
--- a/feedparser/encodings.py
+++ b/feedparser/encodings.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import, unicode_literals
 
 import cgi
 import codecs
-import collections
 import re
 
 try:
@@ -241,7 +240,7 @@ def convert_to_utf8(http_headers, data, result):
     # try: HTTP encoding, declared XML encoding, encoding sniffed from BOM
     for proposed_encoding in (rfc3023_encoding, xml_encoding, bom_encoding,
                               lazy_chardet_encoding, 'utf-8', 'windows-1252', 'iso-8859-2'):
-        if isinstance(proposed_encoding, collections.Callable):
+        if callable(proposed_encoding):
             proposed_encoding = proposed_encoding(data)
         if not proposed_encoding:
             continue


### PR DESCRIPTION
Accessing Callable from collections is deprecated (should be from
collections.abc), but simply calling callable works here.