### PR TITLE
Catch `AttributeError` in `_parse_date`

### DIFF
--- a/feedparser/datetimes/__init__.py
+++ b/feedparser/datetimes/__init__.py
@@ -21,7 +21,7 @@ def _parse_date(dateString):
     for handler in _date_handlers:
         try:
             date9tuple = handler(dateString)
-        except (KeyError, OverflowError, ValueError):
+        except (KeyError, OverflowError, ValueError, AttributeError):
             continue
         if not date9tuple:
             continue


### PR DESCRIPTION
According to the [documentation](https://pythonhosted.org/feedparser/date-parsing.html) if a 3rd party date handler raises any exception, `feedparser` should silently ignore it, and try other registered date handlers.  Coincidently, a feed that I've been working with uses the same date format as the 3rd party handler in the example on that page,  the `AttributeError` that is raised if a match is not found is not ignored.  All tests pass after having made the change, though I do not have python 3.4, 3.5 or 3.7 installed in order to test using them.

Finally, please let me express my gratitude for writing / maintaining this library, it's been great to use and forms the heart of one of my side-projects.