### PR TITLE
Shunted SSL to TLSv1 permanently to fix insecure and deprecated ciphe…

### DIFF
--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -6,6 +6,9 @@ import re
 import struct
 import zlib
 
+import ssl
+ssl.PROTOCOL_SSLv23 = ssl.PROTOCOL_TLSv1
+
 try:
     import urllib.parse
     import urllib.request


### PR DESCRIPTION
As discussed in https://github.com/kurtmckee/feedparser/issues/168

This patch resolves issues with insecurities in SSL 2 & 3. Kind of hackish, but given that TLS is the only trustworthy version at this point anyway, it works.