### PR TITLE
Use encodebytes instead of encodestring in Python 3.9.

### DIFF
--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -73,7 +73,10 @@ from .urls import convert_to_idn
 
 # Python 3.1 deprecated decodestring in favor of decodebytes.
 # This can be removed after Python 2.7 support is dropped.
-_base64decode = getattr(base64, 'decodebytes', base64.decodestring)
+try:
+    _base64decode = base64.decodebytes
+except AttributeError:
+    _base64decode = base64.decodestring
 
 try:
     basestring

--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -71,12 +71,7 @@ import base64
 from .datetimes import _parse_date
 from .urls import convert_to_idn
 
-# Python 3.1 deprecated decodestring in favor of decodebytes.
-# This can be removed after Python 2.7 support is dropped.
-try:
-    _base64decode = base64.decodebytes
-except AttributeError:
-    _base64decode = base64.decodestring
+_base64decode = base64.decodebytes
 
 try:
     basestring

--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -50,7 +50,10 @@ from .urls import _urljoin, make_safe_absolute_uri, resolve_relative_uris
 
 # Python 2.7 only offers "decodestring()".
 # This name substitution can be removed when Python 2.7 support is dropped.
-_base64decode = getattr(base64, 'decodebytes', base64.decodestring)
+try:
+    _base64decode = base64.decodebytes
+except AttributeError:
+    _base64decode = base64.decodestring
 
 
 bytes_ = type(b'')

--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -48,12 +48,7 @@ from .util import FeedParserDict
 from .urls import _urljoin, make_safe_absolute_uri, resolve_relative_uris
 
 
-# Python 2.7 only offers "decodestring()".
-# This name substitution can be removed when Python 2.7 support is dropped.
-try:
-    _base64decode = base64.decodebytes
-except AttributeError:
-    _base64decode = base64.decodestring
+_base64decode = base64.decodebytes
 
 
 bytes_ = type(b'')


### PR DESCRIPTION
Fixes #201 