### PR TITLE
support 'Yes' for itunes:block

### DIFF
--- a/feedparser/namespaces/itunes.py
+++ b/feedparser/namespaces/itunes.py
@@ -102,7 +102,7 @@ class Namespace(object):
 
     def _end_itunes_block(self):
         value = self.pop('itunes_block', 0)
-        self._get_context()['itunes_block'] = (value == 'yes') and 1 or 0
+        self._get_context()['itunes_block'] = (value == 'yes' or value == 'Yes') and 1 or 0
 
     def _end_itunes_explicit(self):
         value = self.pop('itunes_explicit', 0)


### PR DESCRIPTION
according to Apple's guide,  for <itunes:block>, only Yes is accepted

https://help.apple.com/itc/podcasts_connect/?lang=en#/itcb54353390

> Specifying the <itunes:block> tag with a Yes value, prevents the entire podcast from appearing in Apple Podcasts.
Specifying any value other than Yes has no effect.