### PR TITLE
Atom: Populate <summary> correctly if it comes after <content>

### DIFF
--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -193,6 +193,7 @@ class _FeedParserMixin(
         self.svgOK = 0
         self.title_depth = -1
         self.depth = 0
+        self.hasContent = 0
         if self.lang:
             self.feeddata['language'] = self.lang.replace('_', '-')
 

--- a/feedparser/namespaces/_base.py
+++ b/feedparser/namespaces/_base.py
@@ -259,6 +259,7 @@ class Namespace(object):
     def _end_item(self):
         self.pop('item')
         self.inentry = 0
+        self.hasContent = 0
     _end_entry = _end_item
 
     def _start_language(self, attrs_d):
@@ -388,7 +389,7 @@ class Namespace(object):
 
     def _start_description(self, attrs_d):
         context = self._get_context()
-        if 'summary' in context:
+        if 'summary' in context and not self.hasContent:
             self._summaryKey = 'content'
             self._start_content(attrs_d)
         else:
@@ -429,7 +430,7 @@ class Namespace(object):
 
     def _start_summary(self, attrs_d):
         context = self._get_context()
-        if 'summary' in context:
+        if 'summary' in context and not self.hasContent:
             self._summaryKey = 'content'
             self._start_content(attrs_d)
         else:
@@ -466,6 +467,7 @@ class Namespace(object):
         self.sourcedata.clear()
 
     def _start_content(self, attrs_d):
+        self.hasContent = 1
         self.push_content('content', attrs_d, 'text/plain', 1)
         src = attrs_d.get('src')
         if src:
@@ -477,6 +479,7 @@ class Namespace(object):
     _start_xhtml_body = _start_body
 
     def _start_content_encoded(self, attrs_d):
+        self.hasContent = 1
         self.push_content('content', attrs_d, 'text/html', 1)
     _start_fullitem = _start_content_encoded
 

--- a/tests/wellformed/atom10/entry_content_and_summary.xml
+++ b/tests/wellformed/atom10/entry_content_and_summary.xml
@@ -1,0 +1,10 @@
+<!--
+Description: entry summary follows content with different value
+Expect:      not bozo and entries[0]['summary'] == 'Summary'
+-->
+<feed xmlns="http://www.w3.org/2005/Atom">
+<entry>
+  <content>Example Atom</content>
+  <summary>Summary</summary>
+</entry>
+</feed>


### PR DESCRIPTION
This fixes #59. It is merely a rebase (with some variable renaming) of @mosasiru's original pull request (PR #60) which was never merged for some reason so that it doesn't conflict with the current develop branch.