### PR TITLE
Maintain numeric result status code in Python>=3.9

### DIFF
--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -203,7 +203,7 @@ def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None,
         result['href'] = f.url.decode('utf-8', 'ignore')
     else:
         result['href'] = f.url
-    result['status'] = getattr(f, 'status', 200)
+    result['status'] = getattr(f, 'status', None) or 200
 
     # Stop processing if the server sent HTTP 304 Not Modified.
     if getattr(f, 'code', 0) == 304:


### PR DESCRIPTION
Starting with Python 3.9, the return value from `urllib.request.urlopen` changed to [always have the `status` attribute](https://docs.python.org/3.9/library/urllib.request.html#urllib.request.urlopen), becoming `None` in cases where it previously was absent. The revised line should work correctly on all supported Python versions, and maintains compatibility for consumers running Python>=3.9.

The regression that this PR fixes was found in rss2email/rss2email/issues/178.