### PR TITLE
Fix stack level for deprecation warnings

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -15,6 +15,7 @@ bug report!
 * `Beat Bolli <https://drbeat.li/>`_
 * `François Boulogne <http://www.sciunto.org/>`_
 * `Jason Diamond <http://injektilo.org/>`_
+* `Jakub Kuczys <https://github.com/jack1142>`_
 * `Fazal Majid <https://majid.info/blog/>`_
 * `Kevin Marks <http://epeus.blogspot.com/>`_
 * `Tom Most <https://github.com/twm/>`_

--- a/changelog.d/20210731_204227_6032823+jack1142_patch_1.rst
+++ b/changelog.d/20210731_204227_6032823+jack1142_patch_1.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+*   Stack level for feedparser's deprecation warnings is now correctly set (#273)

--- a/feedparser/util.py
+++ b/feedparser/util.py
@@ -48,7 +48,7 @@ class FeedParserDict(dict):
         'tagline_detail': 'subtitle_detail',
     }
 
-    def __getitem__(self, key):
+    def __getitem__(self, key, _stacklevel=2):
         """
         :return: A :class:`FeedParserDict`.
         """
@@ -84,7 +84,7 @@ class FeedParserDict(dict):
                     "exist. This fallback will be removed in a future version "
                     "of feedparser.",
                     DeprecationWarning,
-                    stacklevel=2,
+                    stacklevel=_stacklevel,
                 )
                 return dict.__getitem__(self, 'published')
             return dict.__getitem__(self, 'updated')
@@ -100,7 +100,7 @@ class FeedParserDict(dict):
                     "`updated_parsed` doesn't exist. This fallback will be "
                     "removed in a future version of feedparser.",
                     DeprecationWarning,
-                    stacklevel=2,
+                    stacklevel=_stacklevel,
                 )
                 return dict.__getitem__(self, 'published_parsed')
             return dict.__getitem__(self, 'updated_parsed')
@@ -121,7 +121,7 @@ class FeedParserDict(dict):
             # This fix was proposed in issue 328.
             return dict.__contains__(self, key)
         try:
-            self.__getitem__(key)
+            self.__getitem__(key, _stacklevel=3)
         except KeyError:
             return False
         else:
@@ -135,7 +135,7 @@ class FeedParserDict(dict):
         """
 
         try:
-            return self.__getitem__(key)
+            return self.__getitem__(key, _stacklevel=3)
         except KeyError:
             return default
 
@@ -155,7 +155,7 @@ class FeedParserDict(dict):
         # __getattribute__() is called first; this will be called
         # only if an attribute was not already found
         try:
-            return self.__getitem__(key)
+            return self.__getitem__(key, _stacklevel=3)
         except KeyError:
             raise AttributeError("object has no attribute '%s'" % key)
 

--- a/feedparser/util.py
+++ b/feedparser/util.py
@@ -84,6 +84,7 @@ class FeedParserDict(dict):
                     "exist. This fallback will be removed in a future version "
                     "of feedparser.",
                     DeprecationWarning,
+                    stacklevel=2,
                 )
                 return dict.__getitem__(self, 'published')
             return dict.__getitem__(self, 'updated')
@@ -99,6 +100,7 @@ class FeedParserDict(dict):
                     "`updated_parsed` doesn't exist. This fallback will be "
                     "removed in a future version of feedparser.",
                     DeprecationWarning,
+                    stacklevel=2,
                 )
                 return dict.__getitem__(self, 'published_parsed')
             return dict.__getitem__(self, 'updated_parsed')


### PR DESCRIPTION
This ensures that the warning is shown for the code that is actually the reason for the deprecation warning rather than having the warning show on feedparser's own code. This also makes it easier to suppress the deprecation warning correctly for the code that already has proper handling while not suppressing it on the code that is possibly prone to the issue.