### PR TITLE
Drop dependency on sgmllib3k

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ include = ["feedparser/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-sgmllib3k = "^1.0.0"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
*sgmllib3k* is completely (and intentionally) unmaintained, and doesn't seem to be actually used by *feedparser*, as far as I can tell. Furthermore, sgmllib3k requires pyparsing < 3, which causes compatibility issues with the latest versions of Python 3 (meaning I couldn't even install feedparser).

If SGML support is really needed still, the Python 3 docs [claim it is included in the standard library anyway](https://python.readthedocs.io/en/stable/library/markup.html).