### PR TITLE
add test support 3.10

### DIFF
--- a/.github/workflows/feedparser.yml
+++ b/.github/workflows/feedparser.yml
@@ -19,6 +19,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
+          - "3.10"
           - "pypy3"
         exclude:
           - os: windows-latest


### PR DESCRIPTION
Looks like this will work fine. We're testing 3.10 and thought we'd bring feedparser along for the ride.