### PR TITLE
Add 3.10 and improve env-without-chardet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ build-backend = "poetry.core.masonry.api"
 legacy_tox_ini = """
 
 [tox]
-envlist = py{39, py3, 38, 37, 36}-{chardet, }, docs, mypy
+envlist = py{310, 39, py3, 38, 37, 36}{-chardet, }, docs, mypy
 skip_missing_interpreters = True
 isolated_build = True
 


### PR DESCRIPTION
Running the test suite, that the envs would show up as `py39-` really bothered me, this fixes that issue by making the dash part of the chardet generation.

Also adds 3.10 support while at it.

And there's something else I noticed: currently the test suite requires a global `sphinx` installed in order to run the "docs" env, is there a strong reason for that?