### PR TITLE
Move info about OS specific file syntax to correct subheading

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -34,16 +34,16 @@ Parsing a feed from a remote :abbr:`URL (Uniform Resource Locator)`
     'Sample Feed'
 
 
+Parsing a feed from a local file
+--------------------------------
+::
+
 The following example assumes you are on Windows, and that you have saved a feed at :file:`c:\\incoming\\atom10.xml`.
 
 .. note::
 
     :program:`Universal Feed Parser` works on any platform that can run
     :program:`Python`; use the path syntax appropriate for your platform.
-
-Parsing a feed from a local file
---------------------------------
-::
 
 
     >>> import feedparser

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -36,7 +36,6 @@ Parsing a feed from a remote :abbr:`URL (Uniform Resource Locator)`
 
 Parsing a feed from a local file
 --------------------------------
-::
 
 The following example assumes you are on Windows, and that you have saved a feed at :file:`c:\\incoming\\atom10.xml`.
 
@@ -45,6 +44,7 @@ The following example assumes you are on Windows, and that you have saved a feed
     :program:`Universal Feed Parser` works on any platform that can run
     :program:`Python`; use the path syntax appropriate for your platform.
 
+::
 
     >>> import feedparser
     >>> d = feedparser.parse(r'c:\incoming\atom10.xml')


### PR DESCRIPTION
While reading the introduction docs, I got a bit confused because the info about the example for parsing a feed from a local file assuming the user is on windows is underneath the heading for parsing a feed from a remote URL.

I think moving it below the subheading it is about makes the docs easier to read

