### PR TITLE
Handle HTTP status 308 (Permanent Redirect) as a redirect

### DIFF
--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -66,6 +66,7 @@ class URLHandler(urllib.request.HTTPDigestAuthHandler, urllib.request.HTTPRedire
     http_error_302 = http_error_301
     http_error_303 = http_error_301
     http_error_307 = http_error_301
+    http_error_308 = http_error_301
 
     def http_error_401(self, req, fp, code, msg, headers):
         # Check if


### PR DESCRIPTION
While researching for a fix for https://github.com/rss2email/rss2email/issues/229, I noticed that feedparser does not handle HTTP status code 308 the same as the other HTTP redirects. The new status code 308 (Permanent Redirect) [was added to the standard](https://www.rfc-editor.org/rfc/rfc7538#section-1) in 2015 as the missing variant of status code 301 (Moved Permanently) which “does not allow changing the request method from POST to GET”.