### PR TITLE
Ignore an `ImportWarning` in PyPy 3.7 on Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,4 +92,16 @@ directory = "htmlcov/"
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
+
+    # PyPy on Linux triggers an ImportWarning from within pyyaml,
+    # which is used by the `responses` package in the test suite:
+    #
+    #   yaml/_yaml.pyx:2: in init yaml._yaml
+    #   can't resolve package from __spec__ or __package__,
+    #   falling back on __name__ and __path__
+    #
+    # https://github.com/yaml/pyyaml/issues/534
+    # https://github.com/cython/cython/issues/1720
+    #
+    "ignore::ImportWarning",
 ]


### PR DESCRIPTION
This occurs when `conftest.py` imports the `responses` module.

The issue has been reported to both pyyaml (https://github.com/yaml/pyyaml/issues/534) and to Cython (https://github.com/cython/cython/issues/1720).