### PR TITLE
Use `code-block` directives with correct syntax highlighting

### DIFF
--- a/changelog.d/20230411_073532_kurtmckee_update_doc_code_blocks.rst
+++ b/changelog.d/20230411_073532_kurtmckee_update_doc_code_blocks.rst
@@ -1,0 +1,4 @@
+Documentation
+-------------
+
+*   Use ``code-block`` directives with correct syntax highlighting.

--- a/docs/atom-detail.rst
+++ b/docs/atom-detail.rst
@@ -10,7 +10,7 @@ the value itself.
 Detailed Information on Feed Elements
 -------------------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')

--- a/docs/basic-existence.rst
+++ b/docs/basic-existence.rst
@@ -11,7 +11,7 @@ dictionary idioms.
 Testing if elements are present
 -------------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')

--- a/docs/bozo.rst
+++ b/docs/bozo.rst
@@ -14,7 +14,7 @@ suggesting this terminology.
 Detecting a non-well-formed feed
 --------------------------------
 
-::
+..  code-block:: pycon
 
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')
     >>> d.bozo

--- a/docs/character-encoding.rst
+++ b/docs/character-encoding.rst
@@ -19,7 +19,7 @@ In :abbr:`XML (Extensible Markup Language)`, the character encoding is optional
 and may be given in the :abbr:`XML (Extensible Markup Language)` declaration in
 the first line of the document, like this:
 
-.. sourcecode:: xml
+..  code-block:: xml
 
     <?xml version="1.0" encoding="utf-8"?>
 
@@ -37,7 +37,7 @@ defaults to UTF-8.
 of specifying the character encoding, as part of the Content-Type :abbr:`HTTP (Hypertext Transfer Protocol)`
 header, which looks like this:
 
-::
+..  code-block:: text
 
     Content-Type: text/html; charset="utf-8"
 

--- a/docs/common-atom-elements.rst
+++ b/docs/common-atom-elements.rst
@@ -64,7 +64,7 @@ The feed elements are available in ``d.feed``.
 Accessing Common Feed Elements
 ------------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')
@@ -88,7 +88,7 @@ the order in which they appear in the original feed, so the first entry is
 Accessing Common Entry Elements
 -------------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')

--- a/docs/common-rss-elements.rst
+++ b/docs/common-rss-elements.rst
@@ -38,8 +38,8 @@ The channel elements are available in ``d.feed``.
 
 Accessing Common Channel Elements
 ---------------------------------
-::
 
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/rss20.xml')
@@ -59,8 +59,8 @@ The items are available in ``d.entries``, which is a list.  You access items in 
 
 Accessing Common Item Elements
 ------------------------------
-::
 
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/rss20.xml')

--- a/docs/content-normalization.rst
+++ b/docs/content-normalization.rst
@@ -15,7 +15,7 @@ You can access the basic elements of an Atom feed using :abbr:`RSS (Rich Site Su
 Accessing an Atom feed as an :abbr:`RSS (Rich Site Summary)` feed
 -----------------------------------------------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')
@@ -43,7 +43,7 @@ The same thing works in reverse: you can access :abbr:`RSS (Rich Site Summary)` 
 Accessing an :abbr:`RSS (Rich Site Summary)` feed as an Atom feed
 -----------------------------------------------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/rss20.xml')

--- a/docs/date-parsing.rst
+++ b/docs/date-parsing.rst
@@ -135,7 +135,7 @@ value, a 9-tuple :program:`Python` date in UTC.
 Registering a third-party date handler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+..  code-block:: python
 
     import feedparser
     import re

--- a/docs/http-authentication.rst
+++ b/docs/http-authentication.rst
@@ -14,7 +14,7 @@ The easiest way is to embed the username and password in the feed
 
 In this example, the username is test and the password is basic.
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('http://test:basic@feedparser.org/docs/examples/basic_auth.xml')
@@ -36,7 +36,7 @@ Downloading a feed protected by digest authentication (the easy but horribly ins
 
 In this example, the username is test and the password is digest.
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('http://test:digest@feedparser.org/docs/examples/digest_auth.xml')
@@ -52,7 +52,7 @@ HTTPBasicAuthHandler is part of the standard `urllib2 <http://docs.python.org/li
 Downloading a feed protected by :abbr:`HTTP (Hypertext Transfer Protocol)` basic authentication (the hard way)
 --------------------------------------------------------------------------------------------------------------
 
-::
+..  code-block:: python
 
     import urllib2, feedparser
 
@@ -84,7 +84,7 @@ since the password will be encrypted before being sent to the server.
 Downloading a feed protected by :abbr:`HTTP (Hypertext Transfer Protocol)` digest authentication (the secure way)
 -----------------------------------------------------------------------------------------------------------------
 
-::
+..  code-block:: python
 
     import urllib2, feedparser
 
@@ -116,7 +116,7 @@ information in the www-authenticate header is probably safe to ignore; the
 Determining that a feed is password-protected
 ---------------------------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/basic_auth.xml')

--- a/docs/http-etag.rst
+++ b/docs/http-etag.rst
@@ -18,7 +18,7 @@ status code (``304``) and no feed data.
 Using ETags to reduce bandwidth
 -------------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')
@@ -46,7 +46,7 @@ status code ``304`` and no feed data.
 Using Last-Modified headers to reduce bandwidth
 -----------------------------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')

--- a/docs/http-other.rst
+++ b/docs/http-other.rst
@@ -12,7 +12,7 @@ headers as a dictionary.  When you download a feed from a remote web server,
 Sending custom :abbr:`HTTP (Hypertext Transfer Protocol)` request headers
 -------------------------------------------------------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom03.xml',
@@ -22,7 +22,7 @@ Sending custom :abbr:`HTTP (Hypertext Transfer Protocol)` request headers
 Accessing other :abbr:`HTTP (Hypertext Transfer Protocol)` response headers
 ---------------------------------------------------------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom03.xml')

--- a/docs/http-redirect.rst
+++ b/docs/http-redirect.rst
@@ -21,7 +21,7 @@ parse the feed.
 Noticing temporary redirects
 ----------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/temporary.xml')
@@ -48,7 +48,7 @@ banned from the server.
 Noticing permanent redirects
 ----------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/permanent.xml')
@@ -72,8 +72,7 @@ may get you banned from the server.
 Noticing feeds marked "gone"
 ----------------------------
 
-::
-
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/gone.xml')

--- a/docs/http-useragent.rst
+++ b/docs/http-useragent.rst
@@ -7,7 +7,7 @@ requests a feed from a web server.
 
 The default User-Agent string looks like this:
 
-::
+..  code-block:: text
 
     UniversalFeedParser/5.0.1 +http://feedparser.org/
 
@@ -19,11 +19,11 @@ you should change the User-Agent to your application name and
 Customizing the User-Agent
 --------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml',
-    agent='MyApp/1.0 +http://example.com/')
+    ... agent='MyApp/1.0 +http://example.com/')
 
 You can also set the User-Agent once, globally, and then call the ``parse``
 function normally.
@@ -32,7 +32,7 @@ function normally.
 Customizing the User-Agent permanently
 --------------------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> feedparser.USER_AGENT = "MyApp/1.0 +http://example.com/"
@@ -49,8 +49,8 @@ override this.
 Customizing the referrer
 ------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml',
-    referrer='http://example.com/')
+    ... referrer='http://example.com/')

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -25,8 +25,8 @@ filename, or a raw string containing feed data in any format.
 
 Parsing a feed from a remote :abbr:`URL (Uniform Resource Locator)`
 -------------------------------------------------------------------
-::
 
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')
@@ -44,7 +44,7 @@ The following example assumes you are on Windows, and that you have saved a feed
     :program:`Universal Feed Parser` works on any platform that can run
     :program:`Python`; use the path syntax appropriate for your platform.
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse(r'c:\incoming\atom10.xml')
@@ -56,8 +56,8 @@ The following example assumes you are on Windows, and that you have saved a feed
 
 Parsing a feed from a string
 ----------------------------
-::
 
+..  code-block:: pycon
 
     >>> import feedparser
     >>> rawdata = """<rss version="2.0">

--- a/docs/namespace-handling.rst
+++ b/docs/namespace-handling.rst
@@ -19,7 +19,7 @@ default namespace, it is listed as ``namespaces['']``.
 Accessing namespaced elements
 -----------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/prism.rdf')

--- a/docs/reference-feed-image.rst
+++ b/docs/reference-feed-image.rst
@@ -75,8 +75,8 @@ Summary)` 0.91.
 .. rubric:: Annotated example
 
 This is a feed image:
-::
 
+..  code-block:: xml
 
     <image>
     <title>Feed logo</title>
@@ -89,8 +89,8 @@ This is a feed image:
 
 
 This feed image could be rendered in :abbr:`HTML (HyperText Markup Language)` as this:
-::
 
+..  code-block:: html
 
     <a href="http://example.org/">
     <img src="http://example.org/logo.png"

--- a/docs/reference-feed-textinput.rst
+++ b/docs/reference-feed-textinput.rst
@@ -46,8 +46,8 @@ of the form.
 .. rubric:: Annotated example
 
 This is a text input in a feed:
-::
 
+..  code-block:: xml
 
     <textInput>
     <title>Go!</title>
@@ -58,8 +58,8 @@ This is a text input in a feed:
 
 
 This is how it could be rendered in :abbr:`HTML (HyperText Markup Language)`:
-::
 
+..  code-block:: html
 
     <form method="get" action="http://example.org/search">
     <label for="keyword">Search this site:</label>

--- a/docs/resolving-relative-links.rst
+++ b/docs/resolving-relative-links.rst
@@ -135,7 +135,7 @@ For example, an xml:base on the root-level element sets the base
 xml:base on the root-level element
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse("$READTHEDOCS_CANONICAL_URL/examples/base.xml")
@@ -151,7 +151,7 @@ An xml:base attribute on an <entry> overrides the xml:base on the parent <feed>.
 Overriding xml:base on an <entry>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse("$READTHEDOCS_CANONICAL_URL/examples/base.xml")
@@ -173,7 +173,7 @@ content.
 Relative links within embedded :abbr:`HTML (HyperText Markup Language)`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse("$READTHEDOCS_CANONICAL_URL/examples/base.xml")
@@ -190,7 +190,7 @@ The xml:base affects other attributes in the element in which it is declared.
 xml:base and sibling attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse("$READTHEDOCS_CANONICAL_URL/examples/base.xml")
@@ -209,7 +209,7 @@ overridden by any child element that declares an xml:base attribute.
 Content-Location :abbr:`HTTP (Hypertext Transfer Protocol)` header
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse("$READTHEDOCS_CANONICAL_URL/examples/http_base.xml")
@@ -229,7 +229,7 @@ by any element that declares an xml:base attribute.
 Feed :abbr:`URL (Uniform Resource Locator)` as default base :abbr:`URI (Uniform Resource Identifier)`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse("$READTHEDOCS_CANONICAL_URL/examples/no_base.xml")
@@ -253,7 +253,7 @@ but not in other contexts such as :ref:`reference.entry.link`.
 How to disable relative :abbr:`URI (Uniform Resource Identifier)` resolution
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/base.xml')

--- a/docs/uncommon-atom.rst
+++ b/docs/uncommon-atom.rst
@@ -11,7 +11,7 @@ list.
 Accessing contributors
 ----------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')
@@ -35,7 +35,7 @@ MIME-style content type, and its rel attribute.
 Accessing multiple links
 ------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')

--- a/docs/uncommon-rss.rst
+++ b/docs/uncommon-rss.rst
@@ -11,7 +11,7 @@ aggregators display as a logo.
 Accessing feed image
 --------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/rss20.xml')
@@ -32,7 +32,7 @@ of tuples, rather than a list of dictionaries.
 Accessing multiple categories
 -----------------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/rss20.xml')
@@ -57,7 +57,7 @@ and makes them available as a list.
 Accessing enclosures
 --------------------
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/rss20.xml')
@@ -75,7 +75,7 @@ Accessing feed cloud
 
 No one is quite sure what a cloud is.
 
-::
+..  code-block:: pycon
 
     >>> import feedparser
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/rss20.xml')

--- a/docs/version-detection.rst
+++ b/docs/version-detection.rst
@@ -9,7 +9,7 @@ applications may choose to handle different feed types in different ways.
 Accessing feed version
 ----------------------
 
-::
+..  code-block:: pycon
 
     >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')
     >>> d.version


### PR DESCRIPTION
Documentation
-------------

*   Use ``code-block`` directives with correct syntax highlighting.
