### PR TITLE
Only run CI when merging ("pushing") to important branches

### DIFF
--- a/.github/workflows/feedparser.yml
+++ b/.github/workflows/feedparser.yml
@@ -1,8 +1,13 @@
 name: "CI"
 
 on:
-  - "push"
-  - "pull_request"
+  pull_request:
+  push:
+    branches:
+      - "develop"
+      - "master"
+      - "main"
+      - "releases"
 
 jobs:
   test:


### PR DESCRIPTION
This should reduce double runs of CI when pushing branches like this one. BUT, I still want CI to run whenever anything merges to important branches!