### PR TITLE
datetimes/rfc822: support non-standard format

### DIFF
--- a/feedparser/datetimes/rfc822.py
+++ b/feedparser/datetimes/rfc822.py
@@ -71,6 +71,7 @@ months = {
 }
 re_separator = re.compile(r"\s|,\s?")
 
+
 def _parse_date_rfc822(date):
     """Parse RFC 822 dates and times
     http://tools.ietf.org/html/rfc822#section-5


### PR DESCRIPTION
Example: 'Fri,24 Nov 2023 18:28:36 -0000'
         ~~~~~~~ No space
