### PR TITLE
datetimes/rfc822: support non-standard format

### DIFF
--- a/feedparser/datetimes/rfc822.py
+++ b/feedparser/datetimes/rfc822.py
@@ -91,6 +91,10 @@ def _parse_date_rfc822(date):
         parts.extend(("00:00:00", "0000"))
     # Remove the day name
     if parts[0][:3] in day_names:
+        # Comma without spaces:
+        # 'Fri,24 Nov 2023 18:28:36 -0000'
+        if "," in parts[0] and parts[0][-1] != ",":
+            parts.insert(1, parts[0].rpartition(",")[2])
         parts = parts[1:]
     if len(parts) < 5:
         # If there are still fewer than five parts, there's not enough

--- a/tests/test_date_parsers.py
+++ b/tests/test_date_parsers.py
@@ -199,6 +199,12 @@ def test_year_10000_date():
             "Thu Aug 30 2012 17:26:16 +0200",
             (2012, 8, 30, 15, 26, 16, 3, 243, 0),
         ),
+        # Comma without spaces
+        (
+            _parse_date_rfc822,
+            "Fri,24 Nov 2023 18:28:36 -0000",
+            (2023, 11, 24, 18, 28, 36, 4, 328, 0),
+        ),
         (_parse_date_rfc822, "Sun, 16 Dec 2012 1:2:3:4 GMT", None),  # invalid time
         (_parse_date_rfc822, "Sun, 16 zzz 2012 11:47:32 GMT", None),  # invalid month
         (


### PR DESCRIPTION
```
Example: 'Fri,24 Nov 2023 18:28:36 -0000'
         ~~~~^~~ No space
```