### PR TITLE
encodings: decode utf-8 with errors='replace' when confident

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -29,3 +29,4 @@ bug report!
 * `Aaron Swartz <http://www.aaronsw.com/>`_
 * `Jakub Wilk <http://jwilk.net/>`_
 * `Nestor Rodriguez <https://github.com/n3s7or>`_
+* `Rong Zhang <https://github.com/Rongronggg9>`_

--- a/changelog.d/20231227_020825_rongronggg9_utf-8_errors_replace.rst
+++ b/changelog.d/20231227_020825_rongronggg9_utf-8_errors_replace.rst
@@ -1,0 +1,7 @@
+Fixed
+-----
+
+*   If the metadata of a feed explicitly indicates that the encoding is UTF-8,
+try decode it with ``errors="replace"`` when decoding fails. This prevents
+feeds from being decoded with wrong encodings when they are mostly UTF-8 but
+contain a few invalid bytes.

--- a/feedparser/__init__.py
+++ b/feedparser/__init__.py
@@ -28,6 +28,7 @@
 from .api import parse
 from .datetimes import registerDateHandler
 from .exceptions import (
+    CharacterEncodingErrorsReplace,
     CharacterEncodingOverride,
     CharacterEncodingUnknown,
     FeedparserError,
@@ -64,6 +65,7 @@ __all__ = (
     "registerDateHandler",
     "FeedParserDict",
     "FeedparserError",
+    "CharacterEncodingErrorsReplace",
     "CharacterEncodingOverride",
     "CharacterEncodingUnknown",
     "NonXMLContentType",

--- a/feedparser/exceptions.py
+++ b/feedparser/exceptions.py
@@ -28,6 +28,7 @@
 
 __all__ = [
     "FeedparserError",
+    "CharacterEncodingErrorsReplace",
     "CharacterEncodingOverride",
     "CharacterEncodingUnknown",
     "NonXMLContentType",
@@ -36,6 +37,10 @@ __all__ = [
 
 
 class FeedparserError(Exception):
+    pass
+
+
+class CharacterEncodingErrorsReplace(FeedparserError):
     pass
 
 

--- a/tests/encoding/bozo_http_application_xml_encoding_utf-8_errors_replace.xml
+++ b/tests/encoding/bozo_http_application_xml_encoding_utf-8_errors_replace.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Header:      Content-type: application/rss+xml
+Description: Replace errors instead of falling back to other encodings when application/*xml w/ encoding="utf-8" header
+Expect:      bozo and encoding == 'utf-8' and entries[0].summary == '𝐔𝐓𝐅-𝟖, 𝑏𝑢𝑡 𝒆��𝒐𝒓𝒔'
+-->
+
+<rss version="2.0">
+<channel>
+<item>
+<description><![CDATA[ 𝐔𝐓𝐅-𝟖, 𝑏𝑢𝑡 𝒆��𝒐𝒓𝒔 ]]></description>
+</item>
+</channel>
+</rss>

--- a/tests/encoding/bozo_http_charset_utf-8_errors_replace.xml
+++ b/tests/encoding/bozo_http_charset_utf-8_errors_replace.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+Header:      Content-type: text/rss+xml; charset="utf-8"
+Description: Replace errors instead of falling back to other encodings when charset="utf-8"
+Expect:      bozo and encoding == 'utf-8' and entries[0].summary == '𝐔𝐓𝐅-𝟖, 𝑏𝑢𝑡 𝒆��𝒐𝒓𝒔'
+-->
+
+<rss version="2.0">
+<channel>
+<item>
+<description><![CDATA[ 𝐔𝐓𝐅-𝟖, 𝑏𝑢𝑡 𝒆��𝒐𝒓𝒔 ]]></description>
+</item>
+</channel>
+</rss>


### PR DESCRIPTION
"Confident" means "metadata of the document explicitly indicates that the encoding is UTF-8".

## Background of the patch

When a UTF-8 feed has a few invalid characters but the rest is fine, feedparser will only parse it as `iso-8859-2` (or other encodings detected by `chardet`, if installed), even if both the HTTP and XML headers explicitly indicate that its encoding is `utf-8`.

To handle it better, we should decode the feed as UTF-8 with `errors='replace'`.

- I met the problem at https://github.com/Rongronggg9/RSS-to-Telegram-Bot/issues/391
	- Feed URL: http://iptvin.ru/component/jcomments/?task=rss&object_id=1000707&object_group=com_content&tmpl=component
	- Snapshot of the feed: [iptvin.xml.gz](https://github.com/kurtmckee/feedparser/files/13762749/iptvin.xml.gz)
	- Snapshot of HTTP headers:
```
Date: Sun, 24 Dec 2023 16:23:48 GMT
Server: Apache/2.0.59 (Win32) PHP/5.1.6
X-Powered-By: PHP/5.1.6
Cache-Control: no-store, no-cache, must-revalidate
Expires: Sun, 24 Dec 2023 16:38:48 GMT
Set-Cookie: REDACTED
P3P: REDACTED
Access-Control-Allow-Origin: *
Transfer-Encoding: chunked
Content-Type: application/rss+xml; charset=utf-8
```