### PR TITLE
Correct parsing of media values

### DIFF
--- a/feedparser/namespaces/mediarss.py
+++ b/feedparser/namespaces/mediarss.py
@@ -49,14 +49,6 @@ class Namespace:
             if term.strip():
                 self._add_tag(term.strip(), None, None)
 
-    def _start_media_title(self, attrs_d):
-        self._start_title(attrs_d)
-
-    def _end_media_title(self):
-        title_depth = self.title_depth
-        self._end_title()
-        self.title_depth = title_depth
-
     def _start_media_group(self, attrs_d):
         # don't do anything, but don't break the enclosed tags either
         pass
@@ -85,10 +77,34 @@ class Namespace:
             context["media_credit"][-1]["content"] = credit
 
     def _start_media_description(self, attrs_d):
-        self._start_description(attrs_d)
+        context = self._get_context()
+        context.setdefault("media_description", [])
+        attrs = attrs_d.copy()
+        if "type" in attrs:
+            attrs["type"] = self.map_content_type(attrs["type"])
+        context["media_description"].append(attrs)
+        self.push("media_desc", 1)
 
     def _end_media_description(self):
-        self._end_description()
+        description_ = self.pop("media_desc")
+        if description_ is not None and description_.strip():
+            context = self._get_context()
+            context["media_description"][-1]["content"] = description_
+
+    def _start_media_title(self, attrs_d):
+        context = self._get_context()
+        context.setdefault("media_title", [])
+        attrs = attrs_d.copy()
+        if "type" in attrs:
+            attrs["type"] = self.map_content_type(attrs["type"])
+        context["media_title"].append(attrs)
+        self.push("title", 1)
+
+    def _end_media_title(self):
+        title_ = self.pop("title")
+        if title_ is not None and title_.strip():
+            context = self._get_context()
+            context["media_title"][-1]["content"] = title_
 
     def _start_media_restriction(self, attrs_d):
         context = self._get_context()

--- a/tests/wellformed/media-rss/item_media_title_type_plain.xml
+++ b/tests/wellformed/media-rss/item_media_title_type_plain.xml
@@ -1,6 +1,6 @@
 <!--
 Description: media:title @type="plain"
-Expect:      not bozo and entries[0]['title_detail']['type'] == 'text/plain'
+Expect:      not bozo and entries[0]['media_title'][0]['type'] == 'text/plain'
 -->
 <rss xmlns:media="http://search.yahoo.com/mrss/">
   <channel>

--- a/tests/wellformed/media-rss/media_content_1.xml
+++ b/tests/wellformed/media-rss/media_content_1.xml
@@ -1,0 +1,16 @@
+<!--
+Description: media_content title and description at entry bottom
+Expect:      entries[0]['summary'] == 'Test description' and entries[0]['media_content'][0]['url'] == 'https://example.com/img.jpg' and entries[0]['media_title'][0]['content'] == 'Media title' and entries[0]['media_title'][0]['type'] == 'text/plain' and entries[0]['media_description'][0]['content'] == 'Media description' and entries[0]['media_description'][0]['type'] == 'text/plain' and entries[0]['media_credit'][0]['content'] == 'Media credit'
+-->
+<feed version="0.3" xmlns="http://purl.org/atom/ns#" xmlns:media="http://search.yahoo.com/mrss/">
+    <entry>
+        <media:content width="644" height="322"
+                       url="https://example.com/img.jpg">
+            <media:title type="plain">Media title</media:title>
+            <media:description type="plain">Media description</media:description>
+            <media:credit scheme="urn:ebu">Media credit</media:credit>
+        </media:content>
+        <title>Example Atom</title>
+        <description>Test description</description>
+    </entry>
+</feed>

--- a/tests/wellformed/media-rss/media_content_2.xml
+++ b/tests/wellformed/media-rss/media_content_2.xml
@@ -1,0 +1,16 @@
+<!--
+Description: media_content title and description at entry top
+Expect:      entries[0]['summary'] == 'Test description' and entries[0]['media_content'][0]['url'] == 'https://example.com/img.jpg' and entries[0]['media_title'][0]['content'] == 'Media title' and entries[0]['media_title'][0]['type'] == 'text/plain' and entries[0]['media_description'][0]['content'] == 'Media description' and entries[0]['media_description'][0]['type'] == 'text/plain' and entries[0]['media_credit'][0]['content'] == 'Media credit'
+-->
+<feed version="0.3" xmlns="http://purl.org/atom/ns#" xmlns:media="http://search.yahoo.com/mrss/">
+    <entry>
+        <title>Example Atom</title>
+        <description>Test description</description>
+        <media:content width="644" height="322"
+                       url="https://example.com/img.jpg">
+            <media:title type="plain">Media title</media:title>
+            <media:description type="plain">Media description</media:description>
+            <media:credit scheme="urn:ebu">Media credit</media:credit>
+        </media:content>
+    </entry>
+</feed>

--- a/tests/wellformed/media-rss/media_content_3.xml
+++ b/tests/wellformed/media-rss/media_content_3.xml
@@ -1,0 +1,22 @@
+<!--
+Description: media_content with multiple media tags
+Expect:      entries[0]['summary'] == 'Test description' and entries[0]['media_content'][0]['url'] == 'https://example.com/img.jpg' and entries[0]['media_title'][0]['content'] == 'Media title' and entries[0]['media_title'][0]['type'] == 'text/plain' and entries[0]['media_description'][0]['content'] == 'Media description' and entries[0]['media_description'][0]['type'] == 'text/plain' and entries[0]['media_credit'][0]['content'] == 'Media credit' and entries[0]['media_content'][1]['url'] == 'https://example.com/img2.jpg' and entries[0]['media_title'][1]['content'] == 'Media title 2' and entries[0]['media_title'][1]['type'] == 'text/plain' and entries[0]['media_description'][1]['content'] == 'Media description 2' and entries[0]['media_description'][0]['type'] == 'text/plain' and entries[0]['media_credit'][1]['content'] == 'Media credit 2'
+-->
+<feed version="0.3" xmlns="http://purl.org/atom/ns#" xmlns:media="http://search.yahoo.com/mrss/">
+    <entry>
+        <title>Example Atom</title>
+        <description>Test description</description>
+        <media:content width="644" height="322"
+                       url="https://example.com/img.jpg">
+            <media:title type="plain">Media title</media:title>
+            <media:description type="plain">Media description</media:description>
+            <media:credit scheme="urn:ebu">Media credit</media:credit>
+        </media:content>
+        <media:content width="644" height="322"
+                       url="https://example.com/img2.jpg">
+            <media:title type="plain">Media title 2</media:title>
+            <media:description type="plain">Media description 2</media:description>
+            <media:credit scheme="urn:ebu">Media credit 2</media:credit>
+        </media:content>
+    </entry>
+</feed>

--- a/tests/wellformed/media-rss/media_group.xml
+++ b/tests/wellformed/media-rss/media_group.xml
@@ -1,6 +1,6 @@
 <!--
 Description: media_group
-Expect:      entries[0]['description'] == 'Test Description' and entries[0]['media_credit'][0]['role'] == 'creator' and entries[0]['media_credit'][0]['content'] == 'Creator' and entries[0]['media_credit'][1]['role'] == 'writer' and entries[0]['media_credit'][1]['content'] == 'Writer' and entries[0]['media_restriction']['relationship'] == 'allow' and entries[0]['media_restriction']['content'] == ['au', 'us'] and entries[0]['media_license']['type'] == 'plain' and entries[0]['media_license']['href'] == 'http://example.com/' and entries[0]['media_license']['content'] == 'License' and entries[0]['media_rating']['content'] == 'adult'
+Expect:      entries[0]['media_description'][0]['content'] == 'Test Description' and entries[0]['media_credit'][0]['role'] == 'creator' and entries[0]['media_credit'][0]['content'] == 'Creator' and entries[0]['media_credit'][1]['role'] == 'writer' and entries[0]['media_credit'][1]['content'] == 'Writer' and entries[0]['media_restriction']['relationship'] == 'allow' and entries[0]['media_restriction']['content'] == ['au', 'us'] and entries[0]['media_license']['type'] == 'plain' and entries[0]['media_license']['href'] == 'http://example.com/' and entries[0]['media_license']['content'] == 'License' and entries[0]['media_rating']['content'] == 'adult'
 -->
 <feed version="0.3" xmlns="http://purl.org/atom/ns#" xmlns:media="http://search.yahoo.com/mrss/">
 <entry>


### PR DESCRIPTION
- They all go into lists.
- They don’t erase the entry title or summary.

See #195 and #53

I do have a parasite `media_desc` attribute that stays here because of list parsing. I haven’t succeeded in getting rid of it while correctly parsing lists.