### PR TITLE
Fix a bug in PrefixFileWrapper

### DIFF
--- a/feedparser/encodings.py
+++ b/feedparser/encodings.py
@@ -623,9 +623,9 @@ class PrefixFileWrapper:
 
         if self.offset < len(self.prefix):
             if size < 0:
-                chunk = self.prefix[self.offset:]
+                chunk = self.prefix[self.offset :]
             else:
-                chunk = self.prefix[self.offset:self.offset + size]
+                chunk = self.prefix[self.offset : self.offset + size]
                 size -= len(chunk)
             buffer += chunk
             self.offset += len(chunk)

--- a/feedparser/encodings.py
+++ b/feedparser/encodings.py
@@ -623,9 +623,9 @@ class PrefixFileWrapper:
 
         if self.offset < len(self.prefix):
             if size < 0:
-                chunk = self.prefix
+                chunk = self.prefix[self.offset:]
             else:
-                chunk = self.prefix[self.offset : self.offset + size]
+                chunk = self.prefix[self.offset:self.offset + size]
                 size -= len(chunk)
             buffer += chunk
             self.offset += len(chunk)

--- a/tests/test_encoding_helpers.py
+++ b/tests/test_encoding_helpers.py
@@ -124,6 +124,10 @@ def test_prefix_file_wrapper(factory):
     assert f.read(0) == b""
     assert f.read() == b"abcdef"
 
+    f = feedparser.encodings.PrefixFileWrapper(b"abc", factory(b"def"))
+    assert f.read(2) == b"ab"
+    assert f.read() == b"cdef"
+
 
 # Each emoji is 4 bytes long when encoded in UTF-8.
 @pytest.mark.parametrize("data", ("😀😛🤯😱", "😀a😛b🤯c😱"))


### PR DESCRIPTION
read(-1) should not include the part of prefix that was returned before.