### PR TITLE
Fix issue #318: test failures when cchardet is installed

### DIFF
--- a/tests/illformed/chardet/big5.xml
+++ b/tests/illformed/chardet/big5.xml
@@ -1,7 +1,7 @@
 <!--
 SkipUnless:   __import__('chardet')
 Description:  Big5 with no encoding information
-Expect:       bozo and encoding == 'Big5'
+Expect:       bozo and encoding in ('Big5', 'BIG5')
 -->
 <feed xmlns="http://www.w3.org/2005/Atom">
 <title>我希望??很容易?其翻?成中文，并有助于改??件。 感?您??本文。</title>

--- a/tests/illformed/chardet/euckr.xml
+++ b/tests/illformed/chardet/euckr.xml
@@ -1,7 +1,7 @@
 <!--
 SkipUnless:   __import__('chardet')
 Description:  EUC-KR with no encoding information
-Expect:       bozo and encoding == 'EUC-KR'
+Expect:       bozo and encoding in ('EUC-KR', 'UHC')
 -->
 <rss>
 <channel>

--- a/tests/illformed/chardet/gb2312.xml
+++ b/tests/illformed/chardet/gb2312.xml
@@ -1,7 +1,7 @@
 <!--
 SkipUnless:   __import__('chardet')
 Description:  GB2312 with no encoding information
-Expect:       bozo and encoding == 'GB2312'
+Expect:       bozo and encoding in ('GB2312', 'GB18030')
 -->
 <rss>
 <channel>

--- a/tests/illformed/chardet/windows1255.xml
+++ b/tests/illformed/chardet/windows1255.xml
@@ -1,7 +1,7 @@
 <!--
 SkipUnless:   __import__('chardet')
 Description:  windows-1255 with no encoding information
-Expect:       bozo and encoding == 'windows-1255'
+Expect:       bozo and encoding in ('windows-1255', 'WINDOWS-1255')
 -->
 <rss>
 <channel>


### PR DESCRIPTION
feedparser imports cchardet or chardet depending on what's installed: https://github.com/kurtmckee/feedparser/blob/11990ea1d8791acc76c67781f1d2011daf0c3a99/feedparser/encodings.py#L37-L40

Although these libraries are mostly equivalent, they return slightly different encoding strings, even though both are correct and lead to succesful decoding. This change allows the tests to be run with either library by accepting both encoding names as correct.