### PR TITLE
Remove the redundant tox `skip_missing_interpreters` setting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+min_version = 4.17.0
 envlist =
     coverage_erase
     py{3.13, 3.12, 3.11, 3.10, 3.9, py3.10, py3.9}{-chardet, }
@@ -10,8 +11,6 @@ labels =
     ci-test-macos = py{3.12, 3.9}-chardet
     ci-test-windows = py{3.12, 3.9}-chardet
     update = update
-skip_missing_interpreters = True
-min_version = 4.17.0
 
 
 [testenv]


### PR DESCRIPTION

This PR removes the redundant tox `skip_missing_interpreters` setting in `tox.ini`.
This codifies the recently-discovered fact that it's true by default.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>