### PR TITLE
fix(html): fix warning in python 3.13

### DIFF
--- a/feedparser/html.py
+++ b/feedparser/html.py
@@ -151,7 +151,9 @@ class BaseHTMLProcessor(sgmllib.SGMLParser):
         :rtype: None
         """
 
-        data = re.sub(r'<!((?!DOCTYPE|--|\[))', r'&lt;!\1', data, flags=re.IGNORECASE, count=1)
+        data = re.sub(
+            r"<!((?!DOCTYPE|--|\[))", r"&lt;!\1", data, flags=re.IGNORECASE, count=1
+        )
         data = re.sub(r"<([^<>\s]+?)\s*/>", self._shorttag_replace, data)
         data = data.replace("&#39;", "'")
         data = data.replace("&#34;", '"')

--- a/feedparser/html.py
+++ b/feedparser/html.py
@@ -151,7 +151,7 @@ class BaseHTMLProcessor(sgmllib.SGMLParser):
         :rtype: None
         """
 
-        data = re.sub(r"<!((?!DOCTYPE|--|\[))", r"&lt;!\1", data, flags=re.IGNORECASE)
+        data = re.sub(r'<!((?!DOCTYPE|--|\[))', r'&lt;!\1', data, flags=re.IGNORECASE, count=1)
         data = re.sub(r"<([^<>\s]+?)\s*/>", self._shorttag_replace, data)
         data = data.replace("&#39;", "'")
         data = data.replace("&#34;", '"')


### PR DESCRIPTION
Closes https://github.com/kurtmckee/feedparser/issues/481

I am using Python 3.13.1, and this warning appeared. This PR was made to fix this warning

```
path\feedparser\html.py:152: DeprecationWarning: 'count' is passed as positional argument
  data = re.sub(r'<!((?!DOCTYPE|--|\[))', r'&lt;!\1', data, re.IGNORECASE)
.
```
