### PR TITLE
Drop support for PyPy 3.9

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Linux (CPython)"
+          - name: "Linux"
             runner: "ubuntu-latest"
             cpythons:
               - "3.9"
@@ -24,16 +24,7 @@ jobs:
               - "3.11"
               - "3.12"
               - "3.13"
-            tox-factors:
-              - "chardet"
-            cache-key-hash-files:
-              - "pyproject.toml"
-              - "requirements/*/requirements.txt"
-
-          - name: "Linux (PyPy)"
-            runner: "ubuntu-latest"
             pypys:
-              - "3.9"
               - "3.10"
             tox-factors:
               - "chardet"

--- a/changelog.d/20241208_112335_kurtmckee_rm_pypy_3_9.rst
+++ b/changelog.d/20241208_112335_kurtmckee_rm_pypy_3_9.rst
@@ -1,4 +1,4 @@
 Python support
 --------------
 
-*   Support PyPy3.
+*   Support PyPy 3.10.

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,12 @@
 min_version = 4.17.0
 envlist =
     coverage_erase
-    py{3.13, 3.12, 3.11, 3.10, 3.9, py3.10, py3.9}{-chardet, }
+    py{3.13, 3.12, 3.11, 3.10, 3.9, py3.10}{-chardet, }
     coverage_report
     docs
     mypy
 labels =
-    ci-test-linux = py{3.13, 3.12, 3.11, 3.10, 3.9, py3.10, py3.9}-chardet
+    ci-test-linux = py{3.13, 3.12, 3.11, 3.10, 3.9, py3.10}-chardet
     ci-test-macos = py{3.12, 3.9}-chardet
     ci-test-windows = py{3.12, 3.9}-chardet
     update = update
@@ -16,7 +16,7 @@ labels =
 [testenv]
 description = Run the test suite ({env_name})
 depends =
-    py{3.13, 3.12, 3.11, 3.10, 3.9, py3.10, py3.9}{-chardet, }: coverage_erase
+    py{3.13, 3.12, 3.11, 3.10, 3.9, py3.10}{-chardet, }: coverage_erase
 package = wheel
 wheel_build_env = build_wheel
 deps =
@@ -37,7 +37,7 @@ commands =
 [testenv:coverage_report]
 description = Report code coverage after testing
 depends =
-    py{3.13, 3.12, 3.11, 3.10, 3.9, py3.10, py3.9}{-chardet, }
+    py{3.13, 3.12, 3.11, 3.10, 3.9, py3.10}{-chardet, }
 deps =
     coverage[toml]
 commands_pre =


### PR DESCRIPTION
PyPy 3.9 support was not yet released, so this manifests only as "Support PyPy 3.10".

Python support
--------------

*   Support PyPy 3.10.
