### PR TITLE
Ignore header case in response_headers parameter

### DIFF
--- a/feedparser/api.py
+++ b/feedparser/api.py
@@ -221,7 +221,10 @@ def parse(
     file.seek(initial_file_offset)
 
     # overwrite existing headers using response_headers
-    result["headers"].update(response_headers or {})
+    # Lowercase the HTTP header keys for comparisons per RFC 2616.
+    response_headers = response_headers or {}
+    extra_headers = {k.lower(): v for k, v in response_headers.items()}
+    result["headers"].update(extra_headers)
 
     try:
         _parse_file_inplace(

--- a/tests/test_parse_parameters.py
+++ b/tests/test_parse_parameters.py
@@ -34,6 +34,16 @@ def test_sanitize_html_off():
     assert d.entries[0].content[0].value == '<script>alert("boo!")</script>'
 
 
+def test_response_headers_case_insensitive():
+    d = feedparser.parse(
+        io.BytesIO(feed_xml),
+        response_headers={"CoNtEnT-LoCaTiOn": "http://example.com/feed"},
+    )
+    assert d.entries[1].content[0].value == (
+        '<a href="http://example.com/boo.html">boo</a>'
+    )
+
+
 def test_resolve_relative_uris_default():
     d = feedparser.parse(
         io.BytesIO(feed_xml),


### PR DESCRIPTION
This was broken in 1e4a5b25e337b18a3295d97e1a8957ac22275d1a, which moved the header case normalization logic into the http client. After that commit, users needed to pass lowercase headers in response_headers in order for them to be interpreted correctly.