### PR TITLE
Drop support for PyPy 3.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,8 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - "develop"
-      - "master"
       - "main"
       - "releases"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,6 @@ jobs:
               - "3.12"
               - "3.13"
             pypys:
-              - "3.10"
               - "3.11"
             tox-factors:
               - "chardet"

--- a/changelog.d/20250707_083311_kurtmckee_pypy_3_11_only.rst
+++ b/changelog.d/20250707_083311_kurtmckee_pypy_3_11_only.rst
@@ -1,0 +1,4 @@
+Python support
+--------------
+
+*   Drop support for PyPy 3.10.

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,12 @@ min_version = 4.17.0
 envlist =
     coverage_erase
     py{3.13, 3.12, 3.11, 3.10, 3.9}{-chardet, }
-    pypy{3.11, 3.10}{-chardet, }
+    pypy{3.11}{-chardet, }
     coverage_report
     docs
     mypy
 labels =
-    ci-test-linux = py{3.13, 3.12, 3.11, 3.10, 3.9}-chardet, pypy{3.11, 3.10}-chardet
+    ci-test-linux = py{3.13, 3.12, 3.11, 3.10, 3.9}-chardet, pypy{3.11}-chardet
     ci-test-macos = py{3.13, 3.9}-chardet
     ci-test-windows = py{3.13, 3.9}-chardet
     update = update
@@ -18,7 +18,7 @@ labels =
 description = Run the test suite ({env_name})
 depends =
     py{3.13, 3.12, 3.11, 3.10, 3.9}{-chardet, }: coverage_erase
-    pypy{3.11, 3.10}{-chardet, }: coverage_erase
+    pypy{3.11}{-chardet, }: coverage_erase
 package = wheel
 wheel_build_env = build_wheel
 deps =
@@ -40,7 +40,7 @@ commands =
 description = Report code coverage after testing
 depends =
     py{3.13, 3.12, 3.11, 3.10, 3.9, py3.10}{-chardet, }
-    pypy{3.11, 3.10}{-chardet, }
+    pypy{3.11}{-chardet, }
 deps =
     coverage[toml]
 commands_pre =


### PR DESCRIPTION

Python support
--------------

*   Drop support for PyPy 3.10.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>