### PR TITLE
Release 6.0.12

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: "html"
+  configuration: "docs/conf.py"
+  fail_on_warning: true

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ feedparser and its unit tests are released under the following license:
 
 ----- begin license block -----
 
-Copyright (C) 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+Copyright (C) 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 Copyright (C) 2002-2008 Mark Pilgrim
 All rights reserved.
 
@@ -38,7 +38,7 @@ released under the following license:
 
 ----- begin license block -----
 
-Copyright (C) 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+Copyright (C) 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 Copyright (C) 2004-2008 Mark Pilgrim. All rights reserved.
 
 Redistribution and use in source (Sphinx ReST) and "compiled" forms (HTML, PDF,

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,10 @@
 coming in the next release:
 
+6.0.12 - 10 September 2025
+    *   Fix an ``AssertionError`` crash that occurs with Python 3.10 and higher. (#304)
+    *   Fix a ``DeprecationWarning`` thrown during calls to ``re.sub``. (#389)
+    *   Add a Read the Docs configuration.
+
 6.0.11 - 9 December 2023
     *   Resolve ``cgi`` module deprecation warnings. (#330)
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 ..
     This file is part of feedparser.
-    Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+    Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
     Copyright 2002-2008 Mark Pilgrim
     Released under the BSD 2-clause license.
 

--- a/changelog.d/20210612_152233_kurtmckee_python3_10.rst
+++ b/changelog.d/20210612_152233_kurtmckee_python3_10.rst
@@ -1,4 +1,0 @@
-Fixed
------
-
-*   Fix a crash that occurs with Python 3.10.0b2.

--- a/changelog.d/20210612_152233_kurtmckee_python3_10.rst
+++ b/changelog.d/20210612_152233_kurtmckee_python3_10.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+*   Fix a crash that occurs with Python 3.10.0b2.

--- a/changelog.d/20220521_105155_kurtmckee_fix_python_3_11_cgi_deprecation.rst
+++ b/changelog.d/20220521_105155_kurtmckee_fix_python_3_11_cgi_deprecation.rst
@@ -1,4 +1,0 @@
-Fixed
------
-
-*   Replace a call to ``cgi.parse_header()``, which causes deprecation warnings in Python 3.11.

--- a/changelog.d/20230219_170632_kurtmckee_fix_rtd.rst
+++ b/changelog.d/20230219_170632_kurtmckee_fix_rtd.rst
@@ -1,4 +1,0 @@
-Stewardship
------------
-
-*   Add a `Read the Docs <https://readthedocs.org/>`_ configuration.

--- a/changelog.d/20230219_170632_kurtmckee_fix_rtd.rst
+++ b/changelog.d/20230219_170632_kurtmckee_fix_rtd.rst
@@ -1,0 +1,4 @@
+Stewardship
+-----------
+
+*   Add a `Read the Docs <https://readthedocs.org/>`_ configuration.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ release = version
 
 # project information
 project = 'feedparser'
-copyright = '2010-2023 Kurt McKee, 2004-2008 Mark Pilgrim'
+copyright = '2010-2025 Kurt McKee, 2004-2008 Mark Pilgrim'
 language = 'en'
 
 # documentation options

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -3,7 +3,7 @@
 Documentation license
 =====================
 
-Copyright 2010-2023 Kurt McKee, 2004-2008 Mark Pilgrim. All rights reserved.
+Copyright 2010-2025 Kurt McKee, 2004-2008 Mark Pilgrim. All rights reserved.
 
 Redistribution and use in source (Sphinx ReST) and "compiled" forms (HTML, PDF,
 PostScript, RTF and so forth) with or without modification, are permitted

--- a/dodo.py
+++ b/dodo.py
@@ -1,5 +1,5 @@
 # This file is part of feedparser.
-# Copyright 2020-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2020-2025 Kurt McKee <contactme@kurtmckee.org>
 # Released under the BSD 2-clause license.
 
 # The tasks defined in this file automates the entire

--- a/feedparser/__init__.py
+++ b/feedparser/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #
@@ -32,7 +32,7 @@ from .util import FeedParserDict
 
 __author__ = 'Kurt McKee <contactme@kurtmckee.org>'
 __license__ = 'BSD 2-clause'
-__version__ = '6.0.11'
+__version__ = '6.0.12'
 
 # HTTP "User-Agent" header to send to servers when downloading feeds.
 # If you are embedding feedparser in a larger application, you should

--- a/feedparser/api.py
+++ b/feedparser/api.py
@@ -1,5 +1,5 @@
 # The public API for feedparser
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/datetimes/__init__.py
+++ b/feedparser/datetimes/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/datetimes/asctime.py
+++ b/feedparser/datetimes/asctime.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/datetimes/greek.py
+++ b/feedparser/datetimes/greek.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/datetimes/hungarian.py
+++ b/feedparser/datetimes/hungarian.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/datetimes/iso8601.py
+++ b/feedparser/datetimes/iso8601.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/datetimes/korean.py
+++ b/feedparser/datetimes/korean.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/datetimes/perforce.py
+++ b/feedparser/datetimes/perforce.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/datetimes/rfc822.py
+++ b/feedparser/datetimes/rfc822.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/datetimes/w3dtf.py
+++ b/feedparser/datetimes/w3dtf.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/encodings.py
+++ b/feedparser/encodings.py
@@ -1,5 +1,5 @@
 # Character encoding routines
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/exceptions.py
+++ b/feedparser/exceptions.py
@@ -1,5 +1,5 @@
 # Exceptions used throughout feedparser
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/html.py
+++ b/feedparser/html.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/html.py
+++ b/feedparser/html.py
@@ -149,7 +149,7 @@ class _BaseHTMLProcessor(sgmllib.SGMLParser, object):
         :rtype: None
         """
 
-        data = re.sub(r'<!((?!DOCTYPE|--|\[))', r'&lt;!\1', data, re.IGNORECASE)
+        data = re.sub(r"<!((?!DOCTYPE|--|\[))", r"&lt;!\1", data, flags=re.IGNORECASE)
         data = re.sub(r'<([^<>\s]+?)\s*/>', self._shorttag_replace, data)
         data = data.replace('&#39;', "'")
         data = data.replace('&#34;', '"')

--- a/feedparser/html.py
+++ b/feedparser/html.py
@@ -349,7 +349,7 @@ class _BaseHTMLProcessor(sgmllib.SGMLParser, object):
 
         try:
             return sgmllib.SGMLParser.parse_declaration(self, i)
-        except sgmllib.SGMLParseError:
+        except (AssertionError, sgmllib.SGMLParseError):
             # Escape the doctype declaration and continue parsing.
             self.handle_data('&lt;')
             return i+1

--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/namespaces/_base.py
+++ b/feedparser/namespaces/_base.py
@@ -1,5 +1,5 @@
 # Support for the Atom, RSS, RDF, and CDF feed formats
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/namespaces/admin.py
+++ b/feedparser/namespaces/admin.py
@@ -1,5 +1,5 @@
 # Support for the administrative elements extension
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/namespaces/cc.py
+++ b/feedparser/namespaces/cc.py
@@ -1,5 +1,5 @@
 # Support for the Creative Commons licensing extensions
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/namespaces/dc.py
+++ b/feedparser/namespaces/dc.py
@@ -1,5 +1,5 @@
 # Support for the Dublin Core metadata extensions
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/namespaces/georss.py
+++ b/feedparser/namespaces/georss.py
@@ -1,5 +1,5 @@
 # Support for the GeoRSS format
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/namespaces/itunes.py
+++ b/feedparser/namespaces/itunes.py
@@ -1,5 +1,5 @@
 # Support for the iTunes format
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/namespaces/mediarss.py
+++ b/feedparser/namespaces/mediarss.py
@@ -1,5 +1,5 @@
 # Support for the Media RSS format
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/namespaces/psc.py
+++ b/feedparser/namespaces/psc.py
@@ -1,5 +1,5 @@
 # Support for the Podlove Simple Chapters format
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/parsers/loose.py
+++ b/feedparser/parsers/loose.py
@@ -1,5 +1,5 @@
 # The loose feed parser that interfaces with an SGML parsing library
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/parsers/strict.py
+++ b/feedparser/parsers/strict.py
@@ -1,5 +1,5 @@
 # The strict feed parser that interfaces with an XML parsing library
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/sanitizer.py
+++ b/feedparser/sanitizer.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/sgml.py
+++ b/feedparser/sgml.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/urls.py
+++ b/feedparser/urls.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/feedparser/util.py
+++ b/feedparser/util.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2002-2008 Mark Pilgrim
 # All rights reserved.
 #

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2023 Kurt McKee <contactme@kurtmckee.org>
+# Copyright 2010-2025 Kurt McKee <contactme@kurtmckee.org>
 # Copyright 2004-2008 Mark Pilgrim
 # All rights reserved.
 #


### PR DESCRIPTION
*   Fix an ``AssertionError`` crash that occurs with Python 3.10 and higher. (#304)
*   Fix a ``DeprecationWarning`` thrown during calls to ``re.sub``. (#389)
*   Add a Read the Docs configuration.
