### PR TITLE
Remove the default User-Agent and global `USER_AGENT` variable

### DIFF
--- a/changelog.d/20251027_112701_kurtmckee_rm_user_agent.rst
+++ b/changelog.d/20251027_112701_kurtmckee_rm_user_agent.rst
@@ -1,0 +1,20 @@
+Breaking changes
+----------------
+
+*   feedparser no longer sends a default User-Agent header.
+    In addition, the module-level ``feedparser.USER_AGENT`` variable
+    has been removed and is no longer respected if set.
+
+    feedparser can be used in violation of sites' Terms of Service,
+    and the default User-Agent header incorrectly associated those violations
+    with the project itself.
+
+    It is not tenable to continue receiving notifications from large companies
+    regarding usage violations that has nothing to do with this project
+    and cannot be resolved by project maintainers,
+    so there will no longer be a default User-Agent header
+    that points at the project.
+
+    As has been documented in this project for nearly 20 years,
+    **developers are still encouraged to set an appropriate User-Agent**
+    when making HTTP requests.

--- a/docs/http-useragent.rst
+++ b/docs/http-useragent.rst
@@ -1,56 +1,35 @@
 User-Agent and Referer Headers
 ==============================
 
-:program:`Universal Feed Parser` sends a default User-Agent string when it
-requests a feed from a web server.
-
-
-The default User-Agent string looks like this:
-
-..  code-block:: text
-
-    feedparser/6.0.11 +https://github.com/kurtmckee/feedparser/
-
-If you are embedding :program:`Universal Feed Parser` in a larger application,
-you should change the User-Agent to your application name and
-:abbr:`URL (Uniform Resource Locator)`.
-
-
 Customizing the User-Agent
 --------------------------
 
-..  code-block:: pycon
+feedparser does not send a User-Agent header
+when it requests a feed from a web server.
 
-    >>> import feedparser
-    >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml',
-    ... agent='MyApp/1.0 +http://example.com/')
-
-You can also set the User-Agent once, globally, and then call the ``parse``
-function normally.
-
-
-Customizing the User-Agent permanently
---------------------------------------
+If you are using feedparser in an application,
+you should set the User-Agent to your application name and
+:abbr:`URL (Uniform Resource Locator)`.
 
 ..  code-block:: pycon
 
     >>> import feedparser
-    >>> feedparser.USER_AGENT = "MyApp/1.0 +http://example.com/"
-    >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml')
-
-
-:program:`Universal Feed Parser` also lets you set the referrer when you
-download a feed from a web server.  This is discouraged, because it is a
-violation of `RFC 2616 <http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.36>`_.
-The default behavior is to send a blank referrer, and you should never need to
-override this.
+    >>> d = feedparser.parse(
+    ...     "$READTHEDOCS_CANONICAL_URL/examples/atom10.xml",
+    ...     agent="MyApp/1.0 +http://domain.example/",
+    ... )
 
 
 Customizing the referrer
 ------------------------
 
+feedparser lets you set the Referer header
+when it requests a feed from a web server.
+
 ..  code-block:: pycon
 
     >>> import feedparser
-    >>> d = feedparser.parse('$READTHEDOCS_CANONICAL_URL/examples/atom10.xml',
-    ... referrer='http://example.com/')
+    >>> d = feedparser.parse(
+    ...     "$READTHEDOCS_CANONICAL_URL/examples/atom10.xml",
+    ...     referrer="https://domain.example/",
+    ... )

--- a/feedparser/__init__.py
+++ b/feedparser/__init__.py
@@ -40,11 +40,6 @@ __author__ = "Kurt McKee <contactme@kurtmckee.org>"
 __license__ = "BSD 2-clause"
 __version__ = "6.0.12"
 
-# HTTP "User-Agent" header to send to servers when downloading feeds.
-# If you are embedding feedparser in a larger application, you should
-# change this to your application name and URL.
-USER_AGENT = "feedparser/%s +https://github.com/kurtmckee/feedparser/" % __version__
-
 # If you want feedparser to automatically resolve all relative URIs, set this
 # to 1.
 RESOLVE_RELATIVE_URIS = 1

--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -47,14 +47,10 @@ ACCEPT_HEADER: str = (
 
 
 def get(url: str, result: dict[str, typing.Any]) -> bytes:
-    from . import USER_AGENT
-
-    agent = USER_AGENT
-
     try:
         response = requests.get(
             url,
-            headers={"User-Agent": agent, "Accept": ACCEPT_HEADER},
+            headers={"Accept": ACCEPT_HEADER},
             timeout=10,
         )
     except requests.RequestException as exception:


### PR DESCRIPTION
Breaking changes
----------------

*   feedparser no longer sends a default User-Agent header.
    In addition, the module-level ``feedparser.USER_AGENT`` variable
    has been removed and is no longer respected if set.

    feedparser can be used in violation of sites' Terms of Service,
    and the default User-Agent header incorrectly associated those violations
    with the project itself.

    It is not tenable to continue receiving notifications from large companies
    regarding usage violations that has nothing to do with this project
    and cannot be resolved by project maintainers,
    so there will no longer be a default User-Agent header
    that points at the project.

    As has been documented in this project for nearly 20 years,
    **developers are still encouraged to set an appropriate User-Agent**
    when making HTTP requests.
