### PR TITLE
docs(CHANGELOG): Link to main branch changelog.d

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Unreleased
 
 Please see the fragment files in the `changelog.d directory`_.
 
-..  _changelog.d directory: https://github.com/kurtmckee/feedparser/tree/master/changelog.d
+..  _changelog.d directory: https://github.com/kurtmckee/feedparser/tree/main/changelog.d
 
 
 ..  scriv-insert-here


### PR DESCRIPTION
The `master` branch was renamed to `releases`, and redirects there, but that branch doesn't have a `changelog.d` directory. The `main` branch does, so the docs should link there instead.