### PR TITLE
Fix JSON Feed parser: use correct key for date_updated and prefer content_html

### DIFF
--- a/feedparser/parsers/json.py
+++ b/feedparser/parsers/json.py
@@ -85,23 +85,23 @@ class JSONParser:
             if src in e:
                 entry[dst] = e[src]
 
-        if "content_text" in e:
-            entry["content"] = c = FeedParserDict()
-            c["value"] = e["content_text"]
-            c["type"] = "text"
-        elif "content_html" in e:
+        if "content_html" in e:
             entry["content"] = c = FeedParserDict()
             c["value"] = sanitize_html(
                 e["content_html"], self.encoding, "application/json"
             )
             c["type"] = "html"
+        elif "content_text" in e:
+            entry["content"] = c = FeedParserDict()
+            c["value"] = e["content_text"]
+            c["type"] = "text"
 
         if "date_published" in e:
             entry["published"] = e["date_published"]
             entry["published_parsed"] = _parse_date(e["date_published"])
         if "date_updated" in e:
-            entry["updated"] = e["date_modified"]
-            entry["updated_parsed"] = _parse_date(e["date_modified"])
+            entry["updated"] = e["date_updated"]
+            entry["updated_parsed"] = _parse_date(e["date_updated"])
 
         if "tags" in e:
             entry["category"] = e["tags"]


### PR DESCRIPTION
Two bugs in the JSON Feed parser:

**1. KeyError when parsing `date_updated`**

`parse_entry()` checks `"date_updated" in e` (correct per the JSON Feed spec) but then reads `e["date_modified"]` which doesn't exist in JSON Feed. Every entry with a `date_updated` field raises a `KeyError`.

```python
# current (broken):
if "date_updated" in e:
    entry["updated"] = e["date_modified"]        # KeyError
    entry["updated_parsed"] = _parse_date(e["date_modified"])  # KeyError

# fixed:
if "date_updated" in e:
    entry["updated"] = e["date_updated"]
    entry["updated_parsed"] = _parse_date(e["date_updated"])
```

**2. `content_text` silently wins over `content_html`**

The current `if/elif` returns `content_text` whenever present, even if `content_html` is also present. The JSON Feed 1.1 spec recommends HTML-capable clients prefer `content_html`. Swapping the branches gives richer content by default and matches the spec intent.

Both bugs are in `feedparser/parsers/json.py`, no new imports needed.
