### PR TITLE
Security: Unrestricted outbound URL fetch enables SSRF in `parse()` URL mode

### DIFF
--- a/feedparser/http.py
+++ b/feedparser/http.py
@@ -27,7 +27,10 @@
 
 from __future__ import annotations
 
+import ipaddress
+import socket
 import typing
+from urllib.parse import urlsplit
 
 import requests
 
@@ -46,12 +49,34 @@ ACCEPT_HEADER: str = (
 )
 
 
+def _is_public_url(url: str) -> bool:
+    try:
+        parsed = urlsplit(url)
+        if parsed.scheme not in {"http", "https"}:
+            return False
+        if not parsed.hostname:
+            return False
+        for address_info in socket.getaddrinfo(parsed.hostname, None):
+            ip = ipaddress.ip_address(address_info[4][0])
+            if not ip.is_global:
+                return False
+    except (ValueError, UnicodeError, socket.gaierror):
+        return False
+    return True
+
+
 def get(url: str, result: dict[str, typing.Any]) -> bytes:
+    if not _is_public_url(url):
+        result["bozo"] = True
+        result["bozo_exception"] = requests.RequestException("Disallowed URL")
+        return b""
+
     try:
         response = requests.get(
             url,
             headers={"Accept": ACCEPT_HEADER},
             timeout=10,
+            allow_redirects=False,
         )
     except requests.RequestException as exception:
         result["bozo"] = True


### PR DESCRIPTION
## Problem

`feedparser.http.get()` performs `requests.get(url, ...)` on caller-provided URLs without host/IP allowlisting, private-network blocking, or scheme hardening at this layer. In services that pass user-controlled feed URLs to `feedparser.parse()`, this can be used to access internal metadata/services (SSRF), especially with default redirect following.

**Severity**: `high`
**File**: `feedparser/http.py`

## Solution

Add a secure URL validation gate before fetching: restrict to `http/https`, resolve DNS and block loopback/link-local/RFC1918 ranges, optionally enforce an allowlist, and disable or tightly control redirects (`allow_redirects=False` or re-validate each redirect target).

## Changes

- `feedparser/http.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
