### PR TITLE
Parse boolean itunes:explicit values (true/false/no)

### DIFF
--- a/changelog.d/_4-say-itunes-explicit.rst
+++ b/changelog.d/_4-say-itunes-explicit.rst
@@ -1,0 +1,7 @@
+Fixed
+-----
+
+*   Map ``<itunes:explicit>`` values ``true`` and ``yes`` to ``True``
+    and ``false``, ``no``, and ``clean`` to ``False``. Previously only
+    ``yes`` and ``clean`` were recognized, so the boolean values defined
+    by the current Apple Podcasts spec were parsed as ``None``. (#524)

--- a/feedparser/namespaces/itunes.py
+++ b/feedparser/namespaces/itunes.py
@@ -105,9 +105,11 @@ class Namespace:
 
     def _end_itunes_explicit(self):
         value = self.pop("itunes_explicit", 0)
-        # Convert 'yes' -> True, 'clean' to False, and any other value to None
-        # False and None both evaluate as False, so the difference can be ignored
-        # by applications that only need to know if the content is explicit.
-        self._get_context()["itunes_explicit"] = (None, False, True)[
-            (value == "yes" and 2) or value == "clean" or 0
-        ]
+        # Modern Apple spec uses true/false; yes/no/clean are legacy values.
+        if value in ("yes", "true"):
+            explicit = True
+        elif value in ("no", "false", "clean"):
+            explicit = False
+        else:
+            explicit = None
+        self._get_context()["itunes_explicit"] = explicit

--- a/tests/wellformed/itunes/itunes_channel_explicit_false.xml
+++ b/tests/wellformed/itunes/itunes_channel_explicit_false.xml
@@ -1,6 +1,6 @@
 <!--
 Description: iTunes explicit="false"
-Expect:      not bozo and feed['itunes_explicit'] is None
+Expect:      not bozo and feed['itunes_explicit'] is False
 -->
 <rss xmlns:itunes="http://www.itunes.com/DTDs/Podcast-1.0.dtd">
 <channel>

--- a/tests/wellformed/itunes/itunes_channel_explicit_no.xml
+++ b/tests/wellformed/itunes/itunes_channel_explicit_no.xml
@@ -1,6 +1,6 @@
 <!--
 Description: iTunes explicit='no'
-Expect:      not bozo and feed['itunes_explicit'] is None
+Expect:      not bozo and feed['itunes_explicit'] is False
 -->
 <rss xmlns:itunes="http://www.itunes.com/DTDs/Podcast-1.0.dtd">
 <channel>

--- a/tests/wellformed/itunes/itunes_channel_explicit_true.xml
+++ b/tests/wellformed/itunes/itunes_channel_explicit_true.xml
@@ -1,6 +1,6 @@
 <!--
 Description: iTunes explicit="true"
-Expect:      not bozo and feed['itunes_explicit'] is None
+Expect:      not bozo and feed['itunes_explicit'] is True
 -->
 <rss xmlns:itunes="http://www.itunes.com/DTDs/Podcast-1.0.dtd">
 <channel>

--- a/tests/wellformed/itunes/itunes_item_explicit_false.xml
+++ b/tests/wellformed/itunes/itunes_item_explicit_false.xml
@@ -1,6 +1,6 @@
 <!--
 Description: iTunes explicit="false"
-Expect:      not bozo and entries[0]['itunes_explicit'] is None
+Expect:      not bozo and entries[0]['itunes_explicit'] is False
 -->
 <rss xmlns:itunes="http://www.itunes.com/DTDs/Podcast-1.0.dtd">
 <channel>

--- a/tests/wellformed/itunes/itunes_item_explicit_no.xml
+++ b/tests/wellformed/itunes/itunes_item_explicit_no.xml
@@ -1,6 +1,6 @@
 <!--
 Description: iTunes explicit='no'
-Expect:      not bozo and entries[0]['itunes_explicit'] is None
+Expect:      not bozo and entries[0]['itunes_explicit'] is False
 -->
 <rss xmlns:itunes="http://www.itunes.com/DTDs/Podcast-1.0.dtd">
 <channel>

--- a/tests/wellformed/itunes/itunes_item_explicit_true.xml
+++ b/tests/wellformed/itunes/itunes_item_explicit_true.xml
@@ -1,6 +1,6 @@
 <!--
 Description: iTunes explicit="true"
-Expect:      not bozo and entries[0]['itunes_explicit'] is None
+Expect:      not bozo and entries[0]['itunes_explicit'] is True
 -->
 <rss xmlns:itunes="http://www.itunes.com/DTDs/Podcast-1.0.dtd">
 <channel>


### PR DESCRIPTION
The current Apple Podcasts spec defines `<itunes:explicit>` as a boolean (`true`/`false`), but feedparser only recognized the legacy `yes`/`clean` values and parsed everything else (including `true`, `false`, and `no`) as `None`. This maps `true`/`yes` to `True` and `false`/`no`/`clean` to `False`.

Closes #524