### PR TITLE
Return an empty enclosures list for items with no link (fixes #340)

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -16,6 +16,7 @@ bug report!
 * `François Boulogne <http://www.sciunto.org/>`_
 * `Adrian Damian <https://death.andgravity.com/>`_
 * `Jason Diamond <http://injektilo.org/>`_
+* `Vincent Gao <https://github.com/gaoflow>`_
 * `Jakub Kuczys <https://github.com/jack1142>`_
 * `Fazal Majid <https://majid.info/blog/>`_
 * `Kevin Marks <http://epeus.blogspot.com/>`_

--- a/changelog.d/_5-gaoflow-340-enclosures.rst
+++ b/changelog.d/_5-gaoflow-340-enclosures.rst
@@ -1,0 +1,6 @@
+Fixed
+-----
+
+*   Accessing ``enclosures`` or ``license`` on a feed or entry that has no
+    link no longer raises an error; ``enclosures`` is now an empty list, as
+    documented. (#340)

--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -173,7 +173,10 @@ class XMLParserMixin(
         if not self._matchnamespaces:
             for k, v in self.namespaces.items():
                 self._matchnamespaces[k.lower()] = v
-        self.feeddata = FeedParserDict()  # feed-level data
+        # Seed an empty link list so the computed "enclosures" and "license"
+        # keys return an empty result instead of raising on feeds that have no
+        # link (the feed-level counterpart of issue #340).
+        self.feeddata = FeedParserDict({"links": []})  # feed-level data
         self.entries = []  # list of entry-level data
         self.version = ""  # feed type/version, see SUPPORTED_VERSIONS
         self.namespaces_in_use = {}  # dictionary of namespaces defined by the feed

--- a/feedparser/namespaces/_base.py
+++ b/feedparser/namespaces/_base.py
@@ -253,7 +253,10 @@ class Namespace:
     _end_copyright = _end_rights
 
     def _start_item(self, attrs_d):
-        self.entries.append(FeedParserDict())
+        # Seed an empty link list so the computed "enclosures" and "license"
+        # keys return an empty result instead of raising KeyError on entries
+        # that have an id but no link (see issue #340).
+        self.entries.append(FeedParserDict({"links": []}))
         self.push("item", 0)
         self.inentry = 1
         self.guidislink = 0

--- a/tests/wellformed/atom10/entry_id_no_link_enclosures.xml
+++ b/tests/wellformed/atom10/entry_id_no_link_enclosures.xml
@@ -1,0 +1,10 @@
+<!--
+Description: entry with an id but no link has an empty enclosures list
+Expect:      not bozo and entries[0]['enclosures'] == []
+-->
+<feed xmlns="http://www.w3.org/2005/Atom">
+<entry>
+  <id>urn:uuid:1</id>
+  <title>Example</title>
+</entry>
+</feed>

--- a/tests/wellformed/atom10/feed_no_link_enclosures.xml
+++ b/tests/wellformed/atom10/feed_no_link_enclosures.xml
@@ -1,0 +1,8 @@
+<!--
+Description: feed with no link has an empty enclosures list
+Expect:      not bozo and feed['enclosures'] == []
+-->
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>urn:uuid:1</id>
+  <title>Example</title>
+</feed>

--- a/tests/wellformed/rss/item_guid_no_link_enclosures.xml
+++ b/tests/wellformed/rss/item_guid_no_link_enclosures.xml
@@ -1,0 +1,12 @@
+<!--
+Description: item with a guid but no link has an empty enclosures list
+Expect:      not bozo and entries[0]['enclosures'] == []
+-->
+<rss version="2.0">
+<channel>
+<item>
+  <guid>urn:uuid:1</guid>
+  <title>Example</title>
+</item>
+</channel>
+</rss>


### PR DESCRIPTION
Fixes #340.

You agreed back in 2023 that this should not crash; since the issue is still open (and was bumped again in 2024) I put together a fix. Happy to defer if you would rather take it from here.

## The bug

Accessing `enclosures` (or `license`) on a feed or entry that has an id but no link crashes instead of returning an empty list:

```python
import feedparser
d = feedparser.parse(
    '<feed xmlns="http://www.w3.org/2005/Atom"><entry><id>urn:x</id></entry></feed>'
)
d.entries[0].enclosures      # AttributeError: object has no attribute 'enclosures'
d.entries[0]['enclosures']   # KeyError: 'links'
```

Reproduced on `main` (6.0.12) for both Atom and RSS. The documented contract is that `enclosures` is always a list.

## Cause

The computed `enclosures` and `license` keys in `feedparser/util.py` iterate over `dict.__getitem__(self, "links")`. The `links` key is only created lazily (`setdefault("links", [])`) when a `<link>` is actually parsed, so an entry or feed with no link never gets it, and the iteration raises `KeyError: 'links'` (surfaced as `AttributeError` on attribute access).

## Fix

Seed an empty `links` list when an entry (`_base.py` `_start_item`) or the feed (`mixin.py.__init__`) is created. `enclosures` then returns `[]` and `license` is simply absent, matching the docs. Bare `FeedParserDict()` instances are deliberately left untouched, so `test_empty` (which asserts `enclosures`/`license` are absent on an empty dict) still holds.

The `util.py` one-liner `dict.get(self, "links", [])` would be simpler, but it breaks `test_empty` because it cannot distinguish a parsed-but-link-less object from a bare dict. Seeding at parse time preserves that distinction.

### Scope note

The issue is about entries, but the identical crash exists at the feed level (`feed.license` / `feed.enclosures` on a feed with no link), so I fixed both. If you would prefer to keep this scoped to the entry case in #340, I am happy to drop the `mixin.py` change and its fixture.

## Tests

Added three well-formed fixtures (an Atom entry, an RSS item, and a feed, each with an id/guid but no link) asserting `enclosures == []`. Without the fix these fail with `KeyError: 'links'`; with it the full suite is green (`4303 passed, 8 skipped`).

Disclosure: I prepared this fix with AI assistance under my direction; I reviewed and verified the change and the tests myself.
