### PR TITLE
fix: strip leading whitespace before encoding detection (fixes #508)

### DIFF
--- a/feedparser/encodings.py
+++ b/feedparser/encodings.py
@@ -177,6 +177,10 @@ def convert_to_utf8(
     elif data[:4] == UTF32LE_MARKER:
         bom_encoding = "utf-32le"
 
+    # Strip leading ASCII whitespace to handle broken feeds that start
+    # with a newline before the XML declaration (gh#508).
+    data = data.lstrip()
+
     tempdata = data
     try:
         if bom_encoding:


### PR DESCRIPTION
When an XML feed starts with a newline before the XML declaration
(e.g. `\n<?xml version="1.0"...`), the encoding detection in
`convert_to_utf8()` fails to find the `<?xml` encoding attribute
because it's not at byte offset 0. This causes a second XML
declaration to be prepended, which trips the SAX parser with
"XML or text declaration not at start of entity".

Fix: strip leading ASCII whitespace from the data after BOM
detection and before encoding sniffing, so that XML declarations
preceded by whitespace are correctly detected.