### PR TITLE
Avoid rescanning malformed author emails

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -16,6 +16,7 @@ bug report!
 * `François Boulogne <http://www.sciunto.org/>`_
 * `Adrian Damian <https://death.andgravity.com/>`_
 * `Jason Diamond <http://injektilo.org/>`_
+* `Vincent Gao <https://github.com/gaoflow>`_
 * `Jakub Kuczys <https://github.com/jack1142>`_
 * `Fazal Majid <https://majid.info/blog/>`_
 * `Kevin Marks <http://epeus.blogspot.com/>`_

--- a/changelog.d/_6-gaoflow-author-email-redos.rst
+++ b/changelog.d/_6-gaoflow-author-email-redos.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+*   Avoid repeated rescans when extracting emails from malformed author values. (#562)

--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -39,6 +39,7 @@ from .urls import _urljoin, make_safe_absolute_uri, resolve_relative_uris
 from .util import FeedParserDict
 
 email_pattern = re.compile(
+    r"(?<![a-zA-Z0-9_.+-])"
     r"(([a-zA-Z0-9_.+-]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)"
     r"|(([a-zA-Z0-9-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(]?))"
     r"(\?subject=\S+)?"

--- a/tests/test_author_email.py
+++ b/tests/test_author_email.py
@@ -1,0 +1,16 @@
+"""Exercise author email extraction."""
+
+import time
+
+from feedparser.mixin import email_pattern
+
+
+def test_email_pattern_rejects_pathological_domain_quickly():
+    """Reject an email-like author without repeatedly rescanning its domain."""
+    author = "user@" + ("a-b." * 5000) + "!"
+
+    start = time.perf_counter()
+    assert email_pattern.search(author) is None
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.1


### PR DESCRIPTION
Summary:
- anchor the author email regex so malformed email-like values are not repeatedly rescanned from inside the same token
- add a regression test for the reported dotted-domain payload
- add the changelog fragment and contributor entry

Fixes #562.

Tests:
- python -m pytest -q
- python -m mypy
- black --check --target-version py310 feedparser/mixin.py tests/test_author_email.py
- isort --check-only feedparser/mixin.py tests/test_author_email.py
- flake8 feedparser/mixin.py tests/test_author_email.py
- python -m compileall -q feedparser tests
- git diff --check