### PR TITLE
Extract the contents of escaped CDATA sections (#440)

### DIFF
--- a/changelog.d/_5-fix-escaped-cdata.rst
+++ b/changelog.d/_5-fix-escaped-cdata.rst
@@ -1,0 +1,7 @@
+Fixed
+-----
+
+*   Extract the contents of an escaped CDATA section instead of dropping
+    them. Previously, a value like ``&lt;![CDATA[text]]&gt;`` (a CDATA
+    section that a feed has XML-escaped) was parsed as an empty string
+    because the HTML processor discarded the marked section. (#440)

--- a/feedparser/html.py
+++ b/feedparser/html.py
@@ -288,6 +288,29 @@ class BaseHTMLProcessor(sgmllib.SGMLParser):
         # Reconstruct original DOCTYPE
         self.pieces.append("<!%s>" % text)
 
+    def unknown_decl(self, data):
+        """
+        :type data: str
+        :rtype: None
+        """
+
+        # Called for a markup declaration that isn't a comment or DOCTYPE,
+        # most commonly a CDATA marked section. ``data`` is the body of the
+        # section, e.g. 'CDATA[some text' for the input '<![CDATA[some text]]>'.
+        #
+        # The base SGMLParser.unknown_decl() silently discards the section,
+        # which drops the character data of a CDATA marked section. This
+        # happens when a feed escapes a CDATA section (e.g. the content of a
+        # <description> is the literal text '<![CDATA[...]]>'); the wrapper
+        # is meaningless once the document has been parsed, so emit the
+        # character data it contains rather than dropping it.
+        if data.startswith("CDATA["):
+            text = data[len("CDATA[") :]
+            # The contents of a CDATA section are character data, so escape
+            # the few characters that are special in the surrounding markup.
+            text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+            self.handle_data(text)
+
     _new_declname_match = re.compile(r"[a-zA-Z][-_.a-zA-Z0-9:]*\s*").match
 
     def _scan_name(self, i, declstartpos):

--- a/tests/wellformed/sgml/escaped_cdata_section.xml
+++ b/tests/wellformed/sgml/escaped_cdata_section.xml
@@ -1,0 +1,11 @@
+<!--
+Description: the contents of an escaped CDATA section are extracted, not dropped
+Expect:      not bozo and entries[0]['description'] == 'some text'
+-->
+<rss version="2.0">
+<channel>
+<item>
+<description>&lt;![CDATA[some text]]&gt;</description>
+</item>
+</channel>
+</rss>


### PR DESCRIPTION
Fixes #440.

### The problem

When a feed XML-escapes a CDATA section, feedparser parses the field as an empty string. For example:

```xml
<description>&lt;![CDATA[some text]]&gt;</description>
```

```pycon
>>> feedparser.parse(rss).entries[0].description
''            # expected: 'some text'
```

After the document is parsed, the text content of `<description>` is the literal string `<![CDATA[some text]]>`. feedparser treats that content as HTML, so it runs through the SGML-based HTML processor, which recognizes `<![CDATA[ ... ]]>` as a marked section and hands its body to `unknown_decl()`. `BaseHTMLProcessor` never overrode `unknown_decl()`, so the base `sgmllib.SGMLParser.unknown_decl()` ran — and its default implementation discards the data. The character data was silently dropped.

This has been reported several times against real-world feeds (e.g. the feeds linked in #440).

### The fix

Override `unknown_decl()` in `BaseHTMLProcessor` to emit the contents of a CDATA marked section instead of discarding them. The contents of a CDATA section are character data, so the few characters that are special in the surrounding markup (`&`, `<`, `>`) are escaped before being emitted. This keeps a script smuggled inside an escaped CDATA section inert — it is rendered as literal text rather than executed.

Real (unescaped) CDATA sections are unaffected: the XML parser strips those before the HTML processor ever sees them.

### Tests

- Added `tests/wellformed/sgml/escaped_cdata_section.xml` covering the reported case (runs under both the strict and loose parsers).
- The full suite passes (`4307 passed`).