### PR TITLE
Pass a sorted list, not an rglob() iterator, to parametrize

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -25,6 +25,7 @@ bug report!
 * `Tom Parker-Shemilt <https://tevps.net>`_
 * `Martin Pool <http://sourcefrog.net/>`_
 * `Sam Ruby <http://intertwingly.net/>`_
+* `Sanjay Santhanam <https://github.com/Sanjays2402>`_
 * `Bernd Schlapsi <https://github.com/brot>`_
 * `Aaron Swartz <http://www.aaronsw.com/>`_
 * `Jakub Wilk <http://jwilk.net/>`_

--- a/changelog.d/20260702_220000_sanjays2402_parametrize_iterator.rst
+++ b/changelog.d/20260702_220000_sanjays2402_parametrize_iterator.rst
@@ -1,0 +1,5 @@
+Project development
+-------------------
+
+*   Pass a sorted list of JSON test paths to ``@pytest.mark.parametrize``
+    instead of the lazy ``rglob()`` iterator, which pytest 10 will reject.

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -4,7 +4,7 @@ import pytest
 
 from .helpers import fail_unless_eval, get_test_data
 
-paths = pathlib.Path("tests/json").rglob("*.json")
+paths = sorted(pathlib.Path("tests/json").rglob("*.json"))
 
 
 @pytest.mark.parametrize("path", paths)


### PR DESCRIPTION
## What breaks

On Python 3.13, `tests/test_json.py` fails to collect on any pytest `>= 9.1`, aborting the **entire** test suite:

```
$ python -m pytest -q
E   pytest.PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
E   Test: tests/test_json.py::test_json, argvalues type: map
E   Please convert to a list or tuple.
=========================== short test summary info ============================
ERROR tests/test_json.py - pytest.PytestRemovedIn10Warning: Passing a non-Col...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

## Root cause

`tests/test_json.py` builds its parametrize argvalues from a lazy iterator:

```python
paths = pathlib.Path("tests/json").rglob("*.json")

@pytest.mark.parametrize("path", paths)
def test_json(path):
    ...
```

In Python 3.13, `pathlib.Path.rglob()` returns a **`map` object** — a non-Collection iterable — not a list:

```python
>>> import pathlib, collections.abc as abc
>>> paths = pathlib.Path("tests/json").rglob("*.json")
>>> type(paths).__name__
'map'
>>> isinstance(paths, abc.Collection)
False
```

pytest 9.1 started emitting `PytestRemovedIn10Warning` when a non-Collection iterable is passed to `@pytest.mark.parametrize`, and **pytest 10 removes support entirely**. Because the test config promotes warnings to errors:

```toml
# pyproject.toml
[tool.pytest.ini_options]
filterwarnings = [
    "error",
]
```

…this already hard-errors at collection on pytest `>= 9.1`. CI is green today only because the requirements pin `pytest==9.0.3`, which does not warn yet — so this is a latent forward-compat break that lands the moment the pin advances (or a contributor runs a newer pytest locally).

`test_json.py` is the only affected site. The sibling modules (`test_entities.py`, `test_ill_formed.py`, `test_well_formed.py`) already consume `rglob()` into a `list` via a `for` loop before parametrizing, so they are safe.

## The fix

Wrap the `rglob()` call in `sorted()`:

```python
paths = sorted(pathlib.Path("tests/json").rglob("*.json"))
```

`sorted()` returns a concrete `list` (a Collection, pytest-10-safe) and, as a bonus, makes the generated parameter IDs deterministic — which matters here because the suite runs `pytest-randomly`. This mirrors how the sibling test modules already build their parametrize inputs.

## Proof (fails without the fix, passes with it)

Per-file stash, forcing the future behavior with `-W error::pytest.PytestRemovedIn10Warning`:

| state | `pytest tests/test_json.py -W error::pytest.PytestRemovedIn10Warning` |
|-------|----------------------------------------------------------------------|
| before (`rglob(...)`) | `ERROR ... 1 error during collection` |
| after (`sorted(rglob(...))`) | `1 passed` |

Full suite with the fix (pytest 9.1.1, `filterwarnings = ["error"]`):

```
4297 passed, 8 skipped
```

Without the fix, the same command aborts at collection (`1 error`) and runs nothing.

## Notes

- Diff is +2/−1 in `tests/test_json.py`, plus a `scriv` changelog fragment and a `CONTRIBUTORS.rst` entry (per the file's request to add your name when submitting patches).
- `flake8`, `black --check`, and `isort --check` all clean on the changed file.
- No production code touched — test-suite forward-compat only.
