### PR TITLE
Flag empty document as bozo with new EmptyDocument exception

### DIFF
--- a/changelog.d/_5-larkindom-empty-document.rst
+++ b/changelog.d/_5-larkindom-empty-document.rst
@@ -1,0 +1,6 @@
+Fixed
+-----
+
+*   Set ``bozo`` and ``bozo_exception`` (to a new ``EmptyDocument`` error)
+    when parsing empty input, instead of silently returning a result that
+    looks like a valid, empty feed. (#461)

--- a/feedparser/__init__.py
+++ b/feedparser/__init__.py
@@ -30,6 +30,7 @@ from .datetimes import registerDateHandler
 from .exceptions import (
     CharacterEncodingOverride,
     CharacterEncodingUnknown,
+    EmptyDocument,
     FeedparserError,
     NonXMLContentType,
     UndeclaredNamespace,
@@ -61,6 +62,7 @@ __all__ = (
     "FeedparserError",
     "CharacterEncodingOverride",
     "CharacterEncodingUnknown",
+    "EmptyDocument",
     "NonXMLContentType",
     "UndeclaredNamespace",
 )

--- a/feedparser/api.py
+++ b/feedparser/api.py
@@ -34,6 +34,7 @@ from typing import IO
 
 from . import http
 from .encodings import MissingEncoding, convert_file_to_utf8
+from .exceptions import EmptyDocument
 from .html import BaseHTMLProcessor
 from .mixin import XMLParserMixin
 from .parsers.json import JSONParser
@@ -214,9 +215,12 @@ def parse(
 
     # at this point, the file is guaranteed to be seekable;
     # we read 1 byte/character to see if it's empty and return early
-    # (this preserves the behavior in 6.0.8)
+    # (this preserves the 6.0.8 behavior of not attempting to parse empty
+    # input, but flags it via bozo instead of silently reporting success)
     initial_file_offset = file.tell()
     if not file.read(1):
+        result["bozo"] = True
+        result["bozo_exception"] = EmptyDocument("document is empty")
         return result
     file.seek(initial_file_offset)
 

--- a/feedparser/exceptions.py
+++ b/feedparser/exceptions.py
@@ -30,6 +30,7 @@ __all__ = [
     "FeedparserError",
     "CharacterEncodingOverride",
     "CharacterEncodingUnknown",
+    "EmptyDocument",
     "NonXMLContentType",
     "UndeclaredNamespace",
 ]
@@ -44,6 +45,10 @@ class CharacterEncodingOverride(FeedparserError):
 
 
 class CharacterEncodingUnknown(FeedparserError):
+    pass
+
+
+class EmptyDocument(FeedparserError):
     pass
 
 

--- a/tests/test_empty_document.py
+++ b/tests/test_empty_document.py
@@ -1,0 +1,23 @@
+import io
+
+import feedparser
+
+
+def test_empty_bytestring_sets_bozo():
+    result = feedparser.parse(io.BytesIO(b""))
+    assert result["bozo"] is True
+    assert isinstance(result["bozo_exception"], feedparser.EmptyDocument)
+    assert result["entries"] == []
+    assert result["feed"] == {}
+
+
+def test_empty_string_sets_bozo():
+    result = feedparser.parse(io.StringIO(""))
+    assert result["bozo"] is True
+    assert isinstance(result["bozo_exception"], feedparser.EmptyDocument)
+
+
+def test_nonempty_feed_does_not_set_bozo_via_empty_document():
+    result = feedparser.parse(b"<feed><entry><title>t</title></entry></feed>")
+    exc = result.get("bozo_exception")
+    assert not isinstance(exc, feedparser.EmptyDocument)


### PR DESCRIPTION
Adds `EmptyDocument` to `feedparser.exceptions`, exports it from `feedparser.__init__`, and sets `bozo`/`bozo_exception` when an empty document is parsed instead of silently returning a valid-looking result. Includes tests and a changelog fragment. Closes #461.