### PR TITLE
Don't crash on a stray width/height end tag

### DIFF
--- a/feedparser/namespaces/_base.py
+++ b/feedparser/namespaces/_base.py
@@ -185,7 +185,8 @@ class Namespace:
         value = self.pop("width")
         try:
             value = int(value)
-        except ValueError:
+        except (ValueError, TypeError):
+            # TypeError: a stray </width> with no matching start tag pops None.
             value = 0
         if self.inimage:
             context = self._get_context()
@@ -198,7 +199,8 @@ class Namespace:
         value = self.pop("height")
         try:
             value = int(value)
-        except ValueError:
+        except (ValueError, TypeError):
+            # TypeError: a stray </height> with no matching start tag pops None.
             value = 0
         if self.inimage:
             context = self._get_context()

--- a/tests/illformed/rss_image_height_stray_end_tag.xml
+++ b/tests/illformed/rss_image_height_stray_end_tag.xml
@@ -1,0 +1,14 @@
+<!--
+Description: a stray </height> end tag with no matching start tag must not crash the parser
+Expect:      bozo and feed['image']['height'] == 0
+-->
+<rss version="2.0">
+<channel>
+<image>
+<url>http://example.org/url</url>
+<title>Sample image</title>
+<link>http://example.org/link</link>
+</height>
+</image>
+</channel>
+</rss>

--- a/tests/illformed/rss_image_width_stray_end_tag.xml
+++ b/tests/illformed/rss_image_width_stray_end_tag.xml
@@ -1,0 +1,14 @@
+<!--
+Description: a stray </width> end tag with no matching start tag must not crash the parser
+Expect:      bozo and feed['image']['width'] == 0
+-->
+<rss version="2.0">
+<channel>
+<image>
+<url>http://example.org/url</url>
+<title>Sample image</title>
+<link>http://example.org/link</link>
+</width>
+</image>
+</channel>
+</rss>


### PR DESCRIPTION
feedparser is contracted to never raise on malformed input, recording problems as `bozo`/`bozo_exception` instead. But `_end_width`/`_end_height` do `int(self.pop(...))` inside `try/except ValueError`. The loose parser fires these end-tag handlers even with no matching start tag (unbalanced tags are normal there), so `pop()` returns `None` and `int(None)` raises `TypeError`, which escapes `feedparser.parse()`.

Minimal trigger: a feed with a stray `</width>` (or `</height>`), e.g. inside an `<image>`.

The handlers already default to 0 for an unparseable value, so this extends the `except` to `TypeError`. Added two ill-formed fixtures under tests/illformed.