### PR TITLE
Don't crash when textInput is nested under an item

### DIFF
--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -759,7 +759,8 @@ class XMLParserMixin(
             context = self.sourcedata
         elif self.inimage and "image" in self.feeddata:
             context = self.feeddata["image"]
-        elif self.intextinput:
+        elif self.intextinput and "textinput" in self.feeddata:
+            # Same guard as image: nested textInput never creates feeddata["textinput"].
             context = self.feeddata["textinput"]
         elif self.inentry:
             context = self.entries[-1]

--- a/feedparser/namespaces/_base.py
+++ b/feedparser/namespaces/_base.py
@@ -122,7 +122,9 @@ class Namespace:
 
     def _start_textinput(self, attrs_d):
         context = self._get_context()
-        context.setdefault("textinput", FeedParserDict())
+        # Channel-level only, matching _start_image so nested item textInput is safe.
+        if not self.inentry:
+            context.setdefault("textinput", FeedParserDict())
         self.intextinput = 1
         self.title_depth = -1
         self.push("textinput", 0)

--- a/tests/illformed/rss_item_nested_textinput.xml
+++ b/tests/illformed/rss_item_nested_textinput.xml
@@ -1,0 +1,17 @@
+<!--
+Description: textInput nested under an item must not KeyError on name/link/description
+Expect:      len(entries) == 1 and entries[0]['title'] == 'item title'
+-->
+<rss version="2.0">
+  <channel>
+    <title>channel</title>
+    <item>
+      <title>item title</title>
+      <textInput>
+        <name>query</name>
+        <link>http://example.com/search</link>
+        <description>Search</description>
+      </textInput>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
A textInput nested under an item sets intextinput without creating feeddata["textinput"], so name/link/description KeyError. Mirror the image path: only create textinput at channel level, and guard the mixin context lookup.