### PR TITLE
Don't crash on non-numeric GeoRSS GML EPSG srsName

### DIFF
--- a/feedparser/namespaces/georss.py
+++ b/feedparser/namespaces/georss.py
@@ -94,6 +94,17 @@ class Namespace:
         context["where"]["srsName"] = srs_name
         context["where"]["srsDimension"] = srs_dimension
 
+    def _swap_for_srs_name(self, srs_name):
+        # Non-numeric EPSG suffixes fall back to GeoRSS default swap, like srsDimension.
+        swap = True
+        if srs_name and "EPSG" in srs_name:
+            try:
+                epsg = int(srs_name.split(":")[-1])
+            except ValueError:
+                return swap
+            swap = bool(epsg in _geogCS)
+        return swap
+
     def _start_gml_point(self, attrs_d):
         self._parse_srs_attrs(attrs_d)
         self.ingeometry = 1
@@ -123,10 +134,7 @@ class Namespace:
         context = self._get_context()
         srs_name = context["where"].get("srsName")
         srs_dimension = context["where"].get("srsDimension", 2)
-        swap = True
-        if srs_name and "EPSG" in srs_name:
-            epsg = int(srs_name.split(":")[-1])
-            swap = bool(epsg in _geogCS)
+        swap = self._swap_for_srs_name(srs_name)
         geometry = _parse_georss_point(this, swap=swap, dims=srs_dimension)
         if geometry:
             self._save_where(geometry)
@@ -139,10 +147,7 @@ class Namespace:
         context = self._get_context()
         srs_name = context["where"].get("srsName")
         srs_dimension = context["where"].get("srsDimension", 2)
-        swap = True
-        if srs_name and "EPSG" in srs_name:
-            epsg = int(srs_name.split(":")[-1])
-            swap = bool(epsg in _geogCS)
+        swap = self._swap_for_srs_name(srs_name)
         geometry = _parse_poslist(this, self.ingeometry, swap=swap, dims=srs_dimension)
         if geometry:
             self._save_where(geometry)

--- a/feedparser/namespaces/georss.py
+++ b/feedparser/namespaces/georss.py
@@ -96,14 +96,15 @@ class Namespace:
 
     def _swap_for_srs_name(self, srs_name):
         # Non-numeric EPSG suffixes fall back to GeoRSS default swap, like srsDimension.
-        swap = True
-        if srs_name and "EPSG" in srs_name:
-            try:
-                epsg = int(srs_name.split(":")[-1])
-            except ValueError:
-                return swap
-            swap = bool(epsg in _geogCS)
-        return swap
+        if not (srs_name and "EPSG" in srs_name):
+            return True
+
+        try:
+            epsg = int(srs_name.split(":")[-1])
+        except ValueError:
+            return True
+
+        return epsg in _geogCS
 
     def _start_gml_point(self, attrs_d):
         self._parse_srs_attrs(attrs_d)

--- a/tests/illformed/geo/gml_point_srsname_non_numeric_epsg.xml
+++ b/tests/illformed/geo/gml_point_srsname_non_numeric_epsg.xml
@@ -8,7 +8,7 @@ Expect: entries[0]['where']['type'] == 'Point' and entries[0]['where']['coordina
   xmlns:gml="http://www.opengis.net/gml">
   <entry>
     <georss:where>
-      <gml:Point srsName="EPSG:abc">
+      <gml:Point srsName="urn:ogc:def:crs:EPSG::abc">
         <gml:pos>1.0 2.0</gml:pos>
       </gml:Point>
     </georss:where>

--- a/tests/illformed/geo/gml_point_srsname_non_numeric_epsg.xml
+++ b/tests/illformed/geo/gml_point_srsname_non_numeric_epsg.xml
@@ -1,0 +1,16 @@
+<!--
+Description: GML Point with non-numeric EPSG srsName
+Expect: entries[0]['where']['type'] == 'Point' and entries[0]['where']['coordinates'] == (2.0, 1.0)
+-->
+<feed
+  xmlns="http://www.w3.org/2005/Atom"
+  xmlns:georss="http://www.georss.org/georss"
+  xmlns:gml="http://www.opengis.net/gml">
+  <entry>
+    <georss:where>
+      <gml:Point srsName="EPSG:abc">
+        <gml:pos>1.0 2.0</gml:pos>
+      </gml:Point>
+    </georss:where>
+  </entry>
+</feed>


### PR DESCRIPTION
georss._end_gml_pos / srsName EPSG int hits ValueError when GML Point srsName=EPSG:abc raises ValueError in parse. This PR fixes the regression with a focused test covering the case.
