### PR TITLE
Bound the author-email match to avoid quadratic parsing on hostile feeds

### DIFF
--- a/changelog.d/20260720_023559_arpitjain099_bound_author_email.rst
+++ b/changelog.d/20260720_023559_arpitjain099_bound_author_email.rst
@@ -1,0 +1,7 @@
+Security
+--------
+
+*   Bound the length of author values passed to the author-email regex.
+    The pattern backtracks quadratically, so a hostile feed with a very long
+    ``<author>`` or ``dc:creator`` value could make parsing consume seconds of
+    CPU. Long values now skip the email match instead.

--- a/feedparser/mixin.py
+++ b/feedparser/mixin.py
@@ -44,6 +44,13 @@ email_pattern = re.compile(
     r"(\?subject=\S+)?"
 )
 
+# Feeds are untrusted input, and the domain part of ``email_pattern``
+# backtracks quadratically on long, almost-matching strings. Only run the
+# search on values short enough to plausibly hold an address: RFC 5321 caps
+# an address at 254 octets, and this leaves plenty of room for a display name
+# alongside it. Anything longer is not a real author string, so skip it.
+EMAIL_PATTERN_MAX_LENGTH = 1000
+
 
 class XMLParserMixin(
     _base.Namespace,
@@ -796,7 +803,10 @@ class XMLParserMixin(
             author, email = context.get(key), None
             if not author:
                 return
-            emailmatch = email_pattern.search(author)
+            if len(author) <= EMAIL_PATTERN_MAX_LENGTH:
+                emailmatch = email_pattern.search(author)
+            else:
+                emailmatch = None
             if emailmatch:
                 email = emailmatch.group(0)
                 # probably a better way to do the following, but it passes

--- a/tests/test_author_email_bound.py
+++ b/tests/test_author_email_bound.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import feedparser
+from feedparser.mixin import EMAIL_PATTERN_MAX_LENGTH
+
+
+def _feed(author: str) -> str:
+    return (
+        '<?xml version="1.0"?>'
+        '<rss version="2.0"><channel><title>t</title>'
+        f"<item><title>x</title><author>{author}</author></item>"
+        "</channel></rss>"
+    )
+
+
+def test_normal_author_email_still_extracted():
+    result = feedparser.parse(_feed("Example editor (me@example.com)"))
+    detail = result.entries[0].author_detail
+    assert detail["name"] == "Example editor"
+    assert detail["email"] == "me@example.com"
+
+
+def test_bare_email_still_extracted():
+    result = feedparser.parse(_feed("me@example.com"))
+    assert result.entries[0].author_detail["email"] == "me@example.com"
+
+
+def test_oversized_author_skips_email_match():
+    # A hostile feed can supply an author value crafted so the email pattern
+    # backtracks quadratically. Values longer than the bound are left alone
+    # instead of being fed to the regex, so parsing stays fast.
+    hostile = "a@" + "a." * 16000 + "!"
+    assert len(hostile) > EMAIL_PATTERN_MAX_LENGTH
+
+    result = feedparser.parse(_feed(hostile))
+
+    assert result.bozo is False
+    # The oversized value is kept verbatim as the name and no email is split
+    # out of it.
+    assert "email" not in result.entries[0].author_detail
+    assert result.entries[0].author_detail["name"] == hostile


### PR DESCRIPTION
Feeds are untrusted input, so any regex run over feed-controlled text needs to stay linear. The author-email pattern in `mixin.py` does not: its domain alternative `(([a-zA-Z0-9-]+\.)+)` overlaps the trailing label group, so on a long, almost-matching value it backtracks quadratically. `_sync_author_detail` runs `email_pattern.search(author)` directly on the text from an `<author>` or `dc:creator` element, with no length bound.

I reproduced it on the current main. A single item whose author is `"a@" + "a."*N + "!"` gives, measuring CPU time on one core:

- N=8000 (author ~16 KB): 1.14 s
- N=16000 (author ~32 KB): 4.54 s

Doubling the input roughly quadruples the time, so a ~64 KB author field is around 19 s. That is enough for one crafted feed to tie up an ingester.

The fix is a length guard: only feed `author` to the pattern when it is short enough to plausibly hold an address. RFC 5321 caps an address at 254 octets, and I left generous room for a display name alongside it, so no real author string is affected. Longer values just skip the email match and keep their name verbatim. After the change the 32 KB case parses in a few milliseconds, and I confirmed the usual forms (`Name (me@example.com)`, a bare `me@example.com`, and `Name <me@example.com>`) still split out the email exactly as before.

Added `tests/test_author_email_bound.py` covering the normal extraction plus an oversized author that must parse without pulling an email out of it. I kept the timing out of the assertions to avoid a flaky test and put the numbers here instead. Full suite passes (4300 passed, 8 skipped) and mypy is clean. There is a Security changelog fragment as well.