### PR TITLE
Remove module-level metadata attributes

### DIFF
--- a/changelog.d/20260730_093543_kurtmckee_rm_in_source_metadata.rst
+++ b/changelog.d/20260730_093543_kurtmckee_rm_in_source_metadata.rst
@@ -1,0 +1,5 @@
+Breaking changes
+----------------
+
+*   Remove ``__author__``, ``__license__``, and ``__version__``
+    as module-level metadata attributes.

--- a/feedparser/__init__.py
+++ b/feedparser/__init__.py
@@ -36,10 +36,6 @@ from .exceptions import (
 )
 from .util import FeedParserDict
 
-__author__ = "Kurt McKee <contactme@kurtmckee.org>"
-__license__ = "BSD 2-clause"
-__version__ = "6.0.14"
-
 # If you want feedparser to automatically resolve all relative URIs, set this
 # to 1.
 RESOLVE_RELATIVE_URIS = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "feedparser"
-version = "6.0.13"
+version = "6.0.14"
 description = "Parse Atom/RSS/JSON feeds in Python"
 readme = "README.rst"
 requires-python = ">=3.10"
@@ -94,6 +94,7 @@ filterwarnings = [
 [tool.scriv]
 version = "literal: pyproject.toml: project.version"
 categories = [
+    "Breaking changes",
     "Python support",
     "Added",
     "Fixed",


### PR DESCRIPTION
Breaking changes
----------------

*   Remove ``__author__``, ``__license__``, and ``__version__``
    as module-level metadata attributes.
